### PR TITLE
Add a render_flashed_messages macro

### DIFF
--- a/flask_bootstrap/templates/bootstrap/utils.html
+++ b/flask_bootstrap/templates/bootstrap/utils.html
@@ -8,3 +8,43 @@
         <link rel="icon" href="{{ filename_or_url }}">
     {%- endif %}
 {% endmacro %}
+
+
+{#  This macro was part of Flask-Bootstrap and was modified under the terms of
+ its BSD License. Copyright (c) 2013, Marc Brinkmann. All rights reserved. #}
+
+{% macro render_flashed_messages(messages=None, container=True, transform={
+  'critical': 'danger',
+  'error': 'danger',
+  'info': 'info',
+  'warning': 'warning',
+  'debug': 'info',
+  'notset': 'info',
+  'message': 'info',
+}, default_category=None, dismissible=False) -%}
+{% with messages = messages or get_flashed_messages(with_categories=True) -%}
+{% if messages -%} {# don't output anything if there are no messages #}
+
+{% if container -%}
+<!-- begin message block -->
+<div class="container flashed-messages">
+  <div class="row">
+    <div class="col-md-12">
+{% endif -%}
+
+{% for cat, msg in messages %}      <div class="alert alert-{{transform.get(cat.lower(), default_category or cat)}}{% if dismissible %} alert-dismissible{% endif %}" role="alert">
+{% if dismissible %}        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>{% endif %}
+        {{msg}}
+      </div>
+{%- endfor -%}
+
+{% if container %}
+    </div>
+  </div>
+</div>
+<!-- end message block -->
+{% endif -%}
+
+{% endif -%}
+{% endwith -%}
+{% endmacro -%}


### PR DESCRIPTION
Following up on #4 ,  and based on bootstrap-flask's implementation, with a name updated to match this project's naming style.

If you are open to this, I'll submit another commit to update the documentation and mention this macro. 

I haven't fully tested this with Bootstrap 4.