### PR TITLE
Fix typo in macros.rst

### DIFF
--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -113,7 +113,7 @@ Example
 
 .. code-block:: jinja
 
-    {% from 'bootstrap/form.html' import render_from %}
+    {% from 'bootstrap/form.html' import render_form %}
 
     {{ render_form(form) }}
 


### PR DESCRIPTION
"form" was accidentally mis-spelled in the documentation, fixing it.