### PR TITLE
macros for rendering form grids

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@ Changelog
 ==========
 
 
+1.0.10
+------
+
+Release date: 2019/01/30
+
+- Added macro render_form_row for rendering a row of a bootstrap grid form.
+- Added macro render_grid_form for rendering a bootstrap grid form.
+
+
 1.0.9
 ------
 

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -167,6 +167,90 @@ API
     :param hiddens: If ``True``, render errors of hidden fields as well. If
                    ``'only'``, render *only* these.
 
+{{ render_form_row() }}
+---------------------
+
+Render a row of a grid form
+
+Example
+~~~~~~~~
+
+.. code-block:: jinja
+
+    {% from 'bootstrap/form.html' import render_form_row %}
+
+    <form method="post">
+        {{ render_form_row([form.first_name, form.surname]) }}
+    </form>
+
+API
+~~~~
+
+.. py:function:: render_form_row(fields,
+                                 row_class='form-row',
+                                 col_class_default='col',
+                                 col_class_dict={})
+
+    Render a bootstrap row with the given fields
+
+    :param fields: An iterable of fields to render in a row.
+    :param row_class: Class to apply to the div intended to represent the row, like ``form-row`` 
+                      or ``row``
+    :param col_class_default: The default class to apply to the div that represents a column
+                                if nothing more specific is said for the div column of the rendered field.
+    :param col_class_dict: A dictionary, mapping field.id to a class definition that should be applied to 
+                            the div column that contains the field.
+                            
+{{ render_grid_form() }}
+---------------------
+Render a customized bootstrap grid form based on the render_form_row calls object.
+
+Example
+~~~~~~~~
+
+.. code-block:: jinja
+
+    {% from 'bootstrap/form.html' import render_grid_form %}
+
+    {{ 
+        render_grid_form(
+            form,
+            rows=[
+                render_form_row([(form.title, 'col-md-2'), form.first_name, form.surname]),
+                render_form_row([(form.addres, 'col-md-6'), (form.city, 'col-md-4'), (form.zip, 'col-md-2')])
+            ]
+        )
+    }}
+
+API
+~~~~
+
+.. py:function:: render_grid_form(form,\
+                    rows,\
+                    action="",\
+                    method="post",\
+                    extra_classes=None,\
+                    role="form",\
+                    enctype=None,\
+                    id="",\
+                    novalidate=False,\
+                    render_kw={})
+
+    Outputs Bootstrap-markup for a complete Flask-WTF form.
+
+    :param form: The form that has the fields to render.
+    :param rows: an iterable, being each element the row to print, which can be rendered using render_form_row.
+    :param method: ``<form>`` method attribute.
+    :param extra_classes: The classes to add to the ``<form>``.
+    :param role: ``<form>`` role attribute.
+    :param enctype: ``<form>`` enctype attribute. If ``None``, will
+                    automatically be set to ``multipart/form-data`` if a
+                    :class:`~wtforms.fields.FileField` is present in the form.
+    :param id: The ``<form>`` id attribute.
+    :param novalidate: Flag that decide whether add ``novalidate`` class in ``<form>``.
+    :param render_kw: A dictionary, specifying custom attributes for the
+                     ``<form>`` tag.
+
 
 {{ render_pager() }}
 ---------------------

--- a/flask_bootstrap/templates/bootstrap/form.html
+++ b/flask_bootstrap/templates/bootstrap/form.html
@@ -246,42 +246,38 @@ action="" is what we want, from http://www.ietf.org/rfc/rfc2396.txt:
     </form>
 {%- endmacro %}
 
-{% macro render_form_row(fields, row_class='form-row', col_class='col') %}
+{% macro render_form_row(fields, row_class='form-row', col_class_default='col', col_class_dict={}) %}
 {#
 fields: an iterable of fields to render in a row.
-  Each element of the iterable should be:
-  - Either a form.field to render.
-  - Or a tuple (form.field, 'col_class') when a custom col_class should be
-    rendered for that field.
 row_class: Class to apply to the div intended to represent the row, like
   'form-row' or 'row'.
-col_class: Default col class to apply if nothing more specific is said about a
-  field.
+col_class_default: Default col class to apply if nothing more specific is said about a field.
+col_class_dict: A dictionary which keys are fields.id and which values are the col_class to apply to the field.
 
 Usages:
 Easiest use with defaults:
 {{ render_form_row([form.first_name, form.surname]) }}
 
 Custom col which should use class col-md-2, and the others the defaults:
-{{ render_form_row([(form.title, 'col-md-2'), form.first_name, form.surname]) }}
+{{ render_form_row([form.title, form.first_name, form.surname], col_class_dict={'title': 'col-md-2'}) }}
 
 Custom col which should use class col-md-2 and modified col_class for the default of the other fields
-{{ render_form_row([(form.title, 'col-md-2'), form.first_name, form.surname], col_class='col-md-5') }}
+{{ render_form_row([form.title, form.first_name, form.surname], col_class='col-md-5', col_class_dict={'title': 'col-md-2'}) }}
 #}
 <div class="{{ row_class }}">
   {% for field in fields %}
-    {% if field is iterable and field is not string %}
-      <div class="{{ field[1] }}">
-        {{ render_field(field[0]) }}
-      </div>
+    {% if field.id in col_class_dict %}
+      {% set col_class = col_class_dict[field.id] %}
     {% else %}
-      <div class="{{ col_class }}">
-        {{ render_field(field) }}
-      </div>
+      {% set col_class = col_class_default %}
     {% endif %}
+    <div class="{{ col_class}}">
+      {{ render_field(field) }}
+    </div>
   {% endfor %}
 </div>
 {% endmacro %}
+
 
 {% macro render_grid_form(
   form,

--- a/flask_bootstrap/templates/bootstrap/form.html
+++ b/flask_bootstrap/templates/bootstrap/form.html
@@ -245,3 +245,102 @@ action="" is what we want, from http://www.ietf.org/rfc/rfc2396.txt:
         {%- endfor %}
     </form>
 {%- endmacro %}
+
+{% macro render_form_row(fields, row_class='form-row', col_class='col') %}
+{#
+fields: an iterable of fields to render in a row.
+  Each element of the iterable should be:
+  - Either a form.field to render.
+  - Or a tuple (form.field, 'col_class') when a custom col_class should be
+    rendered for that field.
+row_class: Class to apply to the div intended to represent the row, like
+  'form-row' or 'row'.
+col_class: Default col class to apply if nothing more specific is said about a
+  field.
+
+Usages:
+Easiest use with defaults:
+{{ render_form_row([form.first_name, form.surname]) }}
+
+Custom col which should use class col-md-2, and the others the defaults:
+{{ render_form_row([(form.title, 'col-md-2'), form.first_name, form.surname]) }}
+
+Custom col which should use class col-md-2 and modified col_class for the default of the other fields
+{{ render_form_row([(form.title, 'col-md-2'), form.first_name, form.surname], col_class='col-md-5') }}
+#}
+<div class="{{ row_class }}">
+  {% for field in fields %}
+    {% if field is iterable and field is not string %}
+      <div class="{{ field[1] }}">
+        {{ render_field(field[0]) }}
+      </div>
+    {% else %}
+      <div class="{{ col_class }}">
+        {{ render_field(field) }}
+      </div>
+    {% endif %}
+  {% endfor %}
+</div>
+{% endmacro %}
+
+{% macro render_grid_form(
+  form,
+  rows,
+  action="",
+  method="post",
+  extra_classes=None,
+  role="form",
+  enctype=None,
+  id="",
+  novalidate=False,
+  render_kw={})
+%}
+{#
+Parameters have the same meaning of render_form. Some render_form Parameters
+that have no sense in this context have been removed. The only new parameter
+is the required paramenter rows, which should be an iterable, being each
+element the row to print, i.e. each element is a call to render_form_row
+with their desired parameters.
+
+Example:
+render_grid_form(
+  form,
+  rows=[
+    render_form_row([(form.title, 'col-md-2'), form.first_name, form.surname]),
+    render_form_row([(form.addres, 'col-md-6'), (form.city, 'col-md-4'), (form.zip, 'col-md-2')])
+  ]
+)
+
+See render_form_row for further column customization.
+
+#}
+  {%- set _enctype = [] %}
+  {%- if enctype is none -%}
+    {%- for field in form %}
+      {%- if field.type == 'FileField' %}
+        {#- for loops come with a fairly watertight scope, so this list-hack is
+        used to be able to set values outside of it #}
+        {%- set _ = _enctype.append('multipart/form-data') -%}
+      {%- endif %}
+    {%- endfor %}
+  {%- else %}
+    {% set _ = _enctype.append(enctype) %}
+  {%- endif %}
+  <form{%- if action != None %} action="{{ action }}"{% endif -%}
+  {%- if id %} id="{{ id }}"{% endif -%}
+  {%- if method %} method="{{ method }}"{% endif %}
+  class="form
+  {%- if extra_classes %} {{ extra_classes }}{% endif -%}"
+  {%- if _enctype[0] %} enctype="{{ _enctype[0] }}"{% endif -%}
+  {%- if role %} role="{{ role }}"{% endif -%}
+  {%- if novalidate %} novalidate{% endif -%}
+  {%- if render_kw %} {{ render_kw|xmlattr }}{% endif -%}>
+  {{ form.hidden_tag() }}
+  {{ form_errors(form, hiddens='only') }}
+
+  {% for row in rows %}
+    {{ row }}
+  {% endfor %}
+
+</form>
+{% endmacro %}

--- a/test_bootstrap_flask.py
+++ b/test_bootstrap_flask.py
@@ -115,6 +115,77 @@ class BootstrapTestCase(unittest.TestCase):
         self.assertIn('<input class="form-control" id="username" name="username"', data)
         self.assertIn('<input class="form-control" id="password" name="password"', data)
 
+    def test_render_form_row(self):
+        @self.app.route('/form')
+        def test():
+            form = HelloForm()
+            return render_template_string('''
+                    {% from 'bootstrap/form.html' import render_form_row %}
+                    {{ render_form_row([form.username, form.password]) }}
+                    ''', form=form)
+        response = self.client.get('/form')
+        data = response.get_data(as_text=True)
+        self.assertIn('<div class="form-row">', data)
+        self.assertIn('<div class="col">', data)
+
+    def test_render_form_row_row_class(self):
+        @self.app.route('/form')
+        def test():
+            form = HelloForm()
+            return render_template_string('''
+                    {% from 'bootstrap/form.html' import render_form_row %}
+                    {{ render_form_row([form.username, form.password], row_class='row') }}
+                    ''', form=form)
+        response = self.client.get('/form')
+        data = response.get_data(as_text=True)
+        self.assertIn('<div class="row">', data)
+
+    def test_render_form_row_col_class_default(self):
+        @self.app.route('/form')
+        def test():
+            form = HelloForm()
+            return render_template_string('''
+                    {% from 'bootstrap/form.html' import render_form_row %}
+                    {{ render_form_row([form.username, form.password], col_class_default='col-md-6') }}
+                    ''', form=form)
+        response = self.client.get('/form')
+        data = response.get_data(as_text=True)
+        self.assertIn('<div class="col-md-6">', data)
+
+    def test_render_form_row_col_class_dict(self):
+        @self.app.route('/form')
+        def test():
+            form = HelloForm()
+            return render_template_string('''
+                    {% from 'bootstrap/form.html' import render_form_row %}
+                    {{ render_form_row([form.username, form.password], col_class_dict={'username': 'col-md-6'}) }}
+                    ''', form=form)
+        response = self.client.get('/form')
+        data = response.get_data(as_text=True)
+        self.assertIn('<div class="col">', data)
+        self.assertIn('<div class="col-md-6">', data)
+
+    def test_render_grid_form(self):
+        @self.app.route('/form')
+        def test():
+            form = HelloForm()
+            return render_template_string('''
+                    {% from 'bootstrap/form.html' import render_grid_form, render_form_row %}
+                    {{
+                        render_grid_form(
+                            form,
+                            rows=[render_form_row([form.username, form.password])]
+                        )
+                    }}
+                    ''', form=form)
+
+        response = self.client.get('/form')
+        data = response.get_data(as_text=True)
+        self.assertIn('<input class="form-control" id="username" name="username"', data)
+        self.assertIn('<input class="form-control" id="password" name="password"', data)
+        self.assertIn('<div class="form-row">', data)
+        self.assertIn('<div class="col">', data)
+
     def test_render_pager(self):
         db = SQLAlchemy(self.app)
 


### PR DESCRIPTION
I have written to macros for rendering form grids:

The first one, `render_form_row`, is in charge of rendering a row of the form, according to the desired classes.
The second one, `render_grid_form`, renders the whole form taking an iterable of calls to the first macro.

I think this is useful when one wants to customize the form but don't want to write the whole bootstrap code required.

The second macro, `render_grid_form` could be merged into render_form, but I haven't done this because for serveral reasons:

- At the moment I use them without having modified the original files, importing them from a file of my project.
- It cannot render automatically the form, because it needs to know the distribution of the fields in rows and cols, and therefore, it needs a parameter to do so.

Let me know if you consider this PR useful.