### PR TITLE
Add more support for form button customization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 - Fix ``enctype`` attribute setting for WTForms ``MultipleFileField`` (`Flask-Bootstrap #198<https://github.com/mbr/flask-bootstrap/issues/198>`__).
 - Fix WTForms field class append bug when using ``render_kw={'class': 'my-class'}`` (`#53 <https://github.com/greyli/bootstrap-flask/issues/53>`__).
 - Fix WTForms field description not showing for ``BooleanField`` (`Flask-Bootstrap #197<https://github.com/mbr/flask-bootstrap/issues/197>`__).
+- Add configuration variable ``BOOTSTRAP_BTN_STYLE``(default to ``primary``) and ``BOOTSTRAP_BTN_SIZE``(default to ``md``) to set default form button style and size globally.
+- Add parameter ``button_style`` and ``button_map`` for ``render_form`` and ``render_field`` to set button style and size.
 
 1.2.0
 ------

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,0 +1,126 @@
+Advanced Usage
+===============
+
+.. _button_customizatoin:
+
+Form Button Customization
+--------------------------
+
+Button Style
+~~~~~~~~~~~~
+
+When you use form related macros, you have a couple ways to style buttons. Before we start to dive into the solutions, let's
+review some Bootstrap basics: In Bootstrap 4, you have 9 normal button style and 8 outline button style, so you have 17 button
+style classes below:
+
+- btn-primary
+- btn-secondary
+- btn-success
+- btn-danger
+- btn-warning
+- btn-info
+- btn-light
+- btn-dark
+- btn-link
+- btn-outline-primary
+- btn-outline-secondary
+- btn-outline-success
+- btn-outline-danger
+- btn-outline-warning
+- btn-outline-info
+- btn-outline-light
+- btn-outline-dark
+
+Remove the ``btn-`` prefix, you will get what we (actually, I) called "Bootstrap button style name":
+
+- primary
+- secondary
+- success
+- danger
+- warning
+- info
+- light
+- dark
+- link
+- outline-primary
+- outline-secondary
+- outline-success
+- outline-danger
+- outline-warning
+- outline-info
+- outline-light
+- outline-dark
+
+You will use these names in Bootstrap-Flask. First, you configuration variables ``BOOTSTRAP_BTN_STYLE`` to set a global form button style:
+
+.. code-block:: python
+
+    from flask import Flask
+    from flask_bootstrap import Bootstrap
+
+    app = Flask(__name__)
+    bootstrap = Bootstrap(app)
+
+    app.config['BOOTSTRAP_BTN_STYLE'] = 'primary'  # default to 'secondary'
+
+
+Or you can use ``button_style`` parameter when using ``render_form``, ``render_field`` and ``render_form_row``, this parameter will overwrite
+``BOOTSTRAP_BTN_STYLE``:
+
+.. code-block:: jinja
+
+    {% from 'bootstrap/form.html' import render_form %}
+
+    {{ render_form(form, button_style='success') }}
+
+Smirily, you can use this way to control the button size. In Bootstrap 4, buttons can have 4 sizes:
+
+- btn-sm
+- btn-md (the default size)
+- btn-lg
+- btn-block
+
+So, the size names used in Bootstrap-Flask will be:
+
+- sm
+- md (the default size)
+- lg
+- block
+
+Now you can use a configuration variable called ``BOOTSTRAP_BTN_STYLE`` to set global form button size:
+
+.. code-block:: python
+
+    from flask import Flask
+    from flask_bootstrap import Bootstrap
+
+    app = Flask(__name__)
+    bootstrap = Bootstrap(app)
+
+    app.config['BOOTSTRAP_BTN_SIZE'] = 'sm'  # default to 'md'
+
+there also a parameter called ``button_size`` in form related macros (it will overwrite ``BOOTSTRAP_BTN_SIZE``):
+
+.. code-block:: jinja
+
+    {% from 'bootstrap/form.html' import render_form %}
+
+    {{ render_form(form, button_size='lg') }}
+
+if you need a **block level small** button (``btn btn-sm btn-block``), you can just do something hacky like this:
+
+.. code-block:: python
+
+    app.config['BOOTSTRAP_BTN_SIZE'] = 'sm btn-block'
+
+What if I have three buttons in one form, and I want they have different styles and sizes? The answer is ``button_map`` parameter in form related macros.
+``button_map`` is a dictionary that mapping button field name to Bootstrap button style names. For example, ``{'submit': 'success'}``.
+Here is a more complicate example:
+
+.. code-block:: jinja
+
+    {% from 'bootstrap/form.html' import render_form %}
+
+    {{ render_form(form, {'submit': 'success', 'cancel': 'secondary', 'delete': 'danger'}) }}
+
+It will overwrite ``button_style`` and ``BOOTSTRAP_BTN_STYLE``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,7 @@
 Bootstrap-Flask
 ===============
 
-`Bootstrap <https://getbootstrap.com>`_ 4 helper for Flask/Jinja2. Based on
-`Flask-Bootstrap <https://github.com/mbr/flask-bootstrap>`__, but
-lighter and better.
+`Bootstrap <https://getbootstrap.com>`_ 4 helper for Flask/Jinja2.
 
 Contents
 ---------
@@ -13,6 +11,7 @@ Contents
 
    basic
    macros
+   advanced
    examples
 
 
@@ -60,3 +59,5 @@ License
 
 This project is licensed under the MIT License (see the
 ``LICENSE`` file for details).
+
+Some macros were part of [Flask-Bootstrap](https://github.com/mbr/flask-bootstrap) and were modified under the terms of its BSD License.

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -88,7 +88,7 @@ Example
 API
 ~~~~
 
-.. py:function:: render_field(field, form_type="basic", horizontal_columns=('lg', 2, 10), button_map={})
+.. py:function:: render_field(field, form_type="basic", horizontal_columns=('lg', 2, 10), button_style="", button_size="", button_map={})
 
     Render a single form field.
 
@@ -98,11 +98,14 @@ API
     :param horizontal_columns: When using the horizontal layout, layout forms
                               like this. Must be a 3-tuple of ``(column-type,
                               left-column-size, right-column-size)``.
-    :param button_map: A dictionary, mapping button field names to Bootstrap category names such as
-                      ``primary``, ``danger`` or ``success``. Buttons not found
-                      in the ``button_map`` will use the ``secondary`` type of
-                      button.
+    :param button_style: Accpet Bootstrap button style name (i.e. priamry, secondary, outline-success, etc.),
+                    default to ``secondary`` (e.g. ``btn-secondary``). This will overwrite config ``BOOTSTRAP_BTN_STYLE``.
+    :param button_size: Accept Bootstrap button size name: sm, md, lg, block, default to ``md``. This will 
+                    overwrite config ``BOOTSTRAP_BTN_SIZE``.
+    :param button_map: A dictionary, mapping button field name to Bootstrap button style names. For example, 
+                      ``{'submit': 'success'}``. This will overwrite ``button_style`` and ``BOOTSTRAP_BTN_STYLE``.
 
+.. tip:: See :ref:`button_customizatoin` to learn how to customize form buttons.
 
 render_form()
 ---------------
@@ -128,6 +131,8 @@ API
                     form_type="basic",\
                     horizontal_columns=('lg', 2, 10),\
                     enctype=None,\
+                    button_style="",\
+                    button_size="",\
                     button_map={},\
                     id="",\
                     novalidate=False,\
@@ -148,10 +153,12 @@ API
     :param enctype: ``<form>`` enctype attribute. If ``None``, will
                     automatically be set to ``multipart/form-data`` if a
                     :class:`~wtforms.fields.FileField` is present in the form.
-    :param button_map: A dictionary, mapping button field names to names such as
-                      ``primary``, ``danger`` or ``success``. For example, 
-                      ``{'submit': 'success'}``. Buttons not found in the
-                      ``button_map`` will use the ``default`` type of button.
+    :param button_style: Accpet Bootstrap button style name (i.e. priamry, secondary, outline-success, etc.),
+                    default to ``secondary`` (e.g. ``btn-secondary``). This will overwrite config ``BOOTSTRAP_BTN_STYLE``.
+    :param button_size: Accept Bootstrap button size name: sm, md, lg, block, default to ``md``. This will 
+                    overwrite config ``BOOTSTRAP_BTN_SIZE``.
+    :param button_map: A dictionary, mapping button field name to Bootstrap button style names. For example, 
+                      ``{'submit': 'success'}``. This will overwrite ``button_style`` and ``BOOTSTRAP_BTN_STYLE``.
     :param id: The ``<form>`` id attribute.
     :param novalidate: Flag that decide whether add ``novalidate`` class in ``<form>``.
     :param render_kw: A dictionary, specifying custom attributes for the
@@ -167,10 +174,12 @@ API
     :param hiddens: If ``True``, render errors of hidden fields as well. If
                    ``'only'``, render *only* these.
 
+.. tip:: See :ref:`button_customizatoin` to learn how to customize form buttons.
+
 render_form_row()
 ------------------
 
-Render a row of a grid form
+Render a row of a grid form.
 
 Example
 ~~~~~~~~
@@ -184,6 +193,10 @@ Example
         {{ render_form_row([form.username, form.password]) }}
         {{ render_form_row([form.remember]) }}
         {{ render_form_row([form.submit]) }}
+        {# Custom col which should use class col-md-2, and the others the defaults: #}
+        {{ render_form_row([form.title, form.first_name, form.surname], col_map={'title': 'col-md-2'}) }}
+        {# Custom col which should use class col-md-2 and modified col class for the default of the other fields: #}
+        {{ render_form_row([form.title, form.first_name, form.surname], col_class_default='col-md-5', col_map={'title': 'col-md-2'}) }}
     </form>
 
 API
@@ -192,10 +205,12 @@ API
 .. py:function:: render_form_row(fields,\
                                  row_class='form-row',\
                                  col_class_default='col',\
-                                 col_map={},
+                                 col_map={},\
+                                 button_style="",\
+                                 button_size="",\
                                  button_map={})
 
-    Render a bootstrap row with the given fields
+    Render a bootstrap row with the given fields.
 
     :param fields: An iterable of fields to render in a row.
     :param row_class: Class to apply to the div intended to represent the row, like ``form-row`` 
@@ -204,17 +219,19 @@ API
                                 if nothing more specific is said for the div column of the rendered field.
     :param col_map: A dictionary, mapping field.name to a class definition that should be applied to 
                             the div column that contains the field. For example: ``col_map={'username': 'col-md-2'})``
-    :param button_map: A dictionary, mapping button field names to Bootstrap category names such as
-                      ``primary``, ``danger`` or ``success``. Buttons not found
-                      in the ``button_map`` will use the ``secondary`` type of
-                      button.
-                            
+    :param button_style: Accpet Bootstrap button style name (i.e. priamry, secondary, outline-success, etc.),
+                    default to ``secondary`` (e.g. ``btn-secondary``). This will overwrite config ``BOOTSTRAP_BTN_STYLE``.
+    :param button_size: Accept Bootstrap button size name: sm, md, lg, block, default to ``md``. This will 
+                    overwrite config ``BOOTSTRAP_BTN_SIZE``.
+    :param button_map: A dictionary, mapping button field name to Bootstrap button style names. For example, 
+                      ``{'submit': 'success'}``. This will overwrite ``button_style`` and ``BOOTSTRAP_BTN_STYLE``.                      
 
+.. tip:: See :ref:`button_customizatoin` to learn how to customize form buttons.
 
 render_pager()
 -----------------
 
-Render a pagination object create by Flask-SQLAlchemy
+Render a pagination object create by Flask-SQLAlchemy.
 
 Example
 ~~~~~~~~

--- a/examples/app.py
+++ b/examples/app.py
@@ -2,7 +2,8 @@
 from flask import Flask, render_template, request, flash, Markup
 
 from flask_wtf import FlaskForm
-from wtforms import StringField, SubmitField, BooleanField, PasswordField, IntegerField, TextField, FormField, SelectField, FieldList
+from wtforms import StringField, SubmitField, BooleanField, PasswordField, IntegerField, TextField,\
+    FormField, SelectField, FieldList
 from wtforms.validators import DataRequired, Length
 
 from flask_bootstrap import Bootstrap
@@ -14,7 +15,7 @@ app.secret_key = 'dev'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
 
-# set default button sytle and size, will be overwritten by macro args
+# set default button sytle and size, will be overwritten by macro parameters
 app.config['BOOTSTRAP_BTN_STYLE'] = 'primary'
 app.config['BOOTSTRAP_BTN_SIZE'] = 'sm'
 
@@ -29,10 +30,17 @@ class HelloForm(FlaskForm):
     submit = SubmitField()
 
 
+class ButtonForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired(), Length(1, 20)])
+    submit = SubmitField()
+    delete = SubmitField()
+    cancel = SubmitField()
+
+
 class TelephoneForm(FlaskForm):
     country_code = IntegerField('Country Code')
-    area_code    = IntegerField('Area Code/Exchange')
-    number       = TextField('Number')
+    area_code = IntegerField('Area Code/Exchange')
+    number = TextField('Number')
 
 
 class IMForm(FlaskForm):
@@ -41,8 +49,8 @@ class IMForm(FlaskForm):
 
 
 class ContactForm(FlaskForm):
-    first_name   = TextField()
-    last_name    = TextField()
+    first_name = TextField()
+    last_name = TextField()
     mobile_phone = FormField(TelephoneForm)
     office_phone = FormField(TelephoneForm)
     emails = FieldList(TextField("Email"), min_entries=3)
@@ -53,7 +61,7 @@ class Message(db.Model):
     id = db.Column(db.Integer, primary_key=True)
 
 
-@app.route('/', methods=['GET', 'POST'])
+@app.route('/')
 def index():
     return render_template('index.html')
 
@@ -61,7 +69,7 @@ def index():
 @app.route('/form', methods=['GET', 'POST'])
 def test_form():
     form = HelloForm()
-    return render_template('form.html', form=form, telephone_form=TelephoneForm(), contact_form=ContactForm(), im_form=IMForm())
+    return render_template('form.html', form=form, telephone_form=TelephoneForm(), contact_form=ContactForm(), im_form=IMForm(), button_form=ButtonForm())
 
 
 @app.route('/nav', methods=['GET', 'POST'])
@@ -86,6 +94,7 @@ def test_pagination():
 @app.route('/static', methods=['GET', 'POST'])
 def test_static():
     return render_template('static.html')
+
 
 @app.route('/flash', methods=['GET', 'POST'])
 def test_flash():

--- a/examples/app.py
+++ b/examples/app.py
@@ -11,6 +11,13 @@ from flask_sqlalchemy import SQLAlchemy
 app = Flask(__name__)
 app.secret_key = 'dev'
 
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+
+# set default button sytle and size, will be overwritten by macro args
+app.config['BOOTSTRAP_BTN_STYLE'] = 'primary'
+app.config['BOOTSTRAP_BTN_SIZE'] = 'sm'
+
 bootstrap = Bootstrap(app)
 db = SQLAlchemy(app)
 

--- a/examples/templates/form.html
+++ b/examples/templates/form.html
@@ -5,6 +5,12 @@
     <h1>render_form</h1>
     {{ render_form(form) }}
 
+    <h1>render_form with custom buttons: button_style + button_size</h1>
+    {{ render_form(form, button_style='danger', button_size='sm') }}
+
+    <h1>render_form with custom buttons: button_map</h1>
+    {{ render_form(form, button_map={'submit': 'btn-success btn-sm btn-block'}) }}
+
     <h1>render_field</h1>
     <form method="post">
     {{ form.csrf_token }}

--- a/examples/templates/form.html
+++ b/examples/templates/form.html
@@ -2,19 +2,22 @@
 {% from 'bootstrap/form.html' import render_form, render_field, render_form_row %}
 
 {% block content %}
+
     <h1>render_form</h1>
     {{ render_form(form) }}
 
-    <h1>render_form with custom buttons: button_style + button_size</h1>
-    {{ render_form(form, button_style='danger', button_size='sm') }}
+    <h1>custom buttons: button_style + button_size</h1>
+    <p>{% raw %}{{ render_form(form, button_style='success', button_size='block') }}{% endraw %}</p>
+    {{ render_form(form, button_style='success', button_size='block') }}
 
-    <h1>render_form with custom buttons: button_map</h1>
-    {{ render_form(form, button_map={'submit': 'btn-success btn-sm btn-block'}) }}
+    <h1>custom buttons: button_map</h1>
+    <p>{% raw %}{{ render_form(button_form, button_map={'submit': 'primary', 'cancel': 'secondary', 'delete': 'danger'}) }}{% endraw %}</p>
+    {{ render_form(button_form, button_map={'submit': 'primary', 'cancel': 'secondary', 'delete': 'danger'}) }}
 
     <h1>render_field</h1>
     <form method="post">
     {{ form.csrf_token }}
-    {{ render_field(form.username) }}
+    {{ render_field(form.username, placeholder='test ofrm me') }}
     {{ render_field(form.password) }}
     {{ render_field(form.remember) }}
     {{ render_field(form.submit) }}

--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -45,7 +45,7 @@ class Bootstrap(object):
         app.jinja_env.add_extension('jinja2.ext.do')
         # default settings
         app.config.setdefault('BOOTSTRAP_SERVE_LOCAL', False)
-        app.config.setdefault('BOOTSTRAP_BTN_STYLE', 'primary')
+        app.config.setdefault('BOOTSTRAP_BTN_STYLE', 'secondary')
         app.config.setdefault('BOOTSTRAP_BTN_SIZE', 'md')
 
     @staticmethod

--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -45,6 +45,8 @@ class Bootstrap(object):
         app.jinja_env.add_extension('jinja2.ext.do')
         # default settings
         app.config.setdefault('BOOTSTRAP_SERVE_LOCAL', False)
+        app.config.setdefault('BOOTSTRAP_BTN_STYLE', 'primary')
+        app.config.setdefault('BOOTSTRAP_BTN_SIZE', 'md')
 
     @staticmethod
     def load_css(version=VERSION_BOOTSTRAP):

--- a/flask_bootstrap/templates/bootstrap/form.html
+++ b/flask_bootstrap/templates/bootstrap/form.html
@@ -33,7 +33,9 @@
 {% macro render_field(field,
                     form_type="basic",
                     horizontal_columns=('lg', 2, 10),
-                    button_map={}) %}
+                    button_map={},
+                    button_style='',
+                    button_size='') %}
 
     {# this is a workaround hack for the more straightforward-code of just passing required=required parameter. older versions of wtforms do not have
 the necessary fix for required=False attributes, but will also not set the required flag in the first place. we skirt the issue using the code below #}
@@ -80,11 +82,21 @@ the necessary fix for required=False attributes, but will also not set the requi
     {%- elif field.type == 'SubmitField' -%}
         {# deal with jinja scoping issues? #}
         {% set field_kwargs = kwargs %}
+        {% set button_classes = button_map.get(field.name) %}
 
         {# note: same issue as above - should check widget, not field type #}
         {% call _hz_form_wrap(horizontal_columns, form_type, True, required=required) %}
-            {{ field(class='btn btn-%s' % button_map.get(field.name, 'secondary'),
-            **field_kwargs) }}
+            {% if button_classes %}
+                {# Start with 1.3.0, button_map was used to pass full multiple btn-* classes #}
+                {% if not button_classes.startswith('btn-') %}
+                    {% set button_classes = 'btn-' + button_classes %}
+                {% endif %}
+                {{ field(class='btn %s' % button_classes, **field_kwargs) }}
+            {% else %}
+                {% set default_button_style = button_style or config.BOOTSTRAP_BTN_STYLE %}
+                {% set default_button_size = button_size or config.BOOTSTRAP_BTN_SIZE %}
+                {{ field(class='btn btn-%s btn-%s' % (default_button_style, default_button_size), **field_kwargs) }}
+            {% endif %}
         {% endcall %}
     {%- elif field.type in ['FormField', 'FieldList'] -%}
         {# note: FormFields are tricky to get right and complex setups requiring
@@ -185,6 +197,9 @@ the necessary fix for required=False attributes, but will also not set the requi
                     horizontal_columns=('lg', 2, 10),
                     enctype=None,
                     button_map={},
+                    button_style="",
+                    button_size="",
+                    button_block="",
                     id="",
                     novalidate=False,
                     render_kw={}) %}
@@ -240,7 +255,9 @@ action="" is what we want, from http://www.ietf.org/rfc/rfc2396.txt:
                 {{ render_field(field,
                     form_type=form_type,
                     horizontal_columns=horizontal_columns,
-                    button_map=button_map) }}
+                    button_map=button_map,
+                    button_style=button_style,
+                    button_size=button_size) }}
             {%- endif %}
         {%- endfor %}
     </form>

--- a/flask_bootstrap/templates/bootstrap/form.html
+++ b/flask_bootstrap/templates/bootstrap/form.html
@@ -204,7 +204,6 @@ the necessary fix for required=False attributes, but will also not set the requi
                     button_map={},
                     button_style="",
                     button_size="",
-                    button_block="",
                     id="",
                     novalidate=False,
                     render_kw={}) %}
@@ -268,28 +267,7 @@ action="" is what we want, from http://www.ietf.org/rfc/rfc2396.txt:
     </form>
 {%- endmacro %}
 
-{% macro render_form_row(fields, row_class='form-row', col_class_default='col', col_map={}, button_map={}) %}
-{#
-fields: an iterable of fields to render in a row.
-row_class: Class to apply to the div intended to represent the row, like
-  'form-row' or 'row'.
-col_class_default: Default col class to apply if nothing more specific is said about a field.
-col_map: A dictionary which keys are fields.name and which values are the col class to apply to the field.
-button_map: A dictionary, mapping button field names to Bootstrap category names.
-
-Usages:
-Easiest use with defaults:
-{{ render_form_row([form.first_name, form.surname]) }}
-
-Custom col which should use class col-md-2, and the others the defaults:
-{{ render_form_row([form.title, form.first_name, form.surname], col_map={'title': 'col-md-2'}) }}
-
-Custom col which should use class col-md-2 and modified col class for the default of the other fields:
-{{ render_form_row([form.title, form.first_name, form.surname], col_class_default='col-md-5', col_map={'title': 'col-md-2'}) }}
-
-Mapping Bootstrap button category to field name:
-{{ render_form_row([form.cancel, form.submit], button_map={'submit': 'primary'}) }}
-#}
+{% macro render_form_row(fields, row_class='form-row', col_class_default='col', col_map={}, button_map={}, button_style='', button_size='') %}
 <div class="{{ row_class }}">
   {% for field in fields %}
     {% if field.name in col_map %}
@@ -298,7 +276,7 @@ Mapping Bootstrap button category to field name:
       {% set col_class = col_class_default %}
     {% endif %}
     <div class="{{ col_class }}">
-      {{ render_field(field, button_map=button_map) }}
+      {{ render_field(field, button_map=button_map, button_style=button_style, button_size=button_size) }}
     </div>
   {% endfor %}
 </div>

--- a/flask_bootstrap/templates/bootstrap/form.html
+++ b/flask_bootstrap/templates/bootstrap/form.html
@@ -87,21 +87,11 @@ the necessary fix for required=False attributes, but will also not set the requi
     {%- elif field.type == 'SubmitField' -%}
         {# deal with jinja scoping issues? #}
         {% set field_kwargs = kwargs %}
-        {% set button_classes = button_map.get(field.name) %}
-
         {# note: same issue as above - should check widget, not field type #}
         {% call _hz_form_wrap(horizontal_columns, form_type, True, required=required) %}
-            {% if button_classes %}
-                {# Start with 1.3.0, button_map was used to pass full multiple btn-* classes #}
-                {% if not button_classes.startswith('btn-') %}
-                    {% set button_classes = 'btn-' + button_classes %}
-                {% endif %}
-                {{ field(class='btn %s %s' % (button_classes, field.render_kw.class), **field_kwargs) }}
-            {% else %}
-                {% set default_button_style = button_style or config.BOOTSTRAP_BTN_STYLE %}
-                {% set default_button_size = button_size or config.BOOTSTRAP_BTN_SIZE %}
-                {{ field(class='btn btn-%s btn-%s %s' % (default_button_style, default_button_size, field.render_kw.class), **field_kwargs) }}
-            {% endif %}
+            {% set default_button_style = button_style or config.BOOTSTRAP_BTN_STYLE %}
+            {% set default_button_size = button_size or config.BOOTSTRAP_BTN_SIZE %}
+            {{ field(class='btn btn-%s btn-%s %s' % (button_map.get(field.name, default_button_style), default_button_size, field.render_kw.class), **field_kwargs) }}
         {% endcall %}
     {%- elif field.type in ['FormField', 'FieldList'] -%}
         {# note: FormFields are tricky to get right and complex setups requiring

--- a/test_bootstrap_flask.py
+++ b/test_bootstrap_flask.py
@@ -361,9 +361,9 @@ class BootstrapTestCase(unittest.TestCase):
         data = response.get_data(as_text=True)
         self.assertIn('multipart/form-data', data)
 
-
     # test render_kw class for WTForms field
     def test_form_render_kw_class(self):
+
         class TestForm(FlaskForm):
             submit = SubmitField(render_kw={'class': 'my-awesome-class'})
 
@@ -380,9 +380,9 @@ class BootstrapTestCase(unittest.TestCase):
         self.assertIn('my-awesome-class', data)
         self.assertIn('btn', data)
 
-
     # test WTForm field description for BooleanField
     def test_form_description_for_booleanfield(self):
+
         class TestForm(FlaskForm):
             remember = BooleanField('Remember me', description='Just check this')
 
@@ -398,3 +398,74 @@ class BootstrapTestCase(unittest.TestCase):
         data = response.get_data(as_text=True)
         self.assertIn('Remember me', data)
         self.assertIn('<small class="form-text text-muted">Just check this</small>', data)
+
+    def test_button_size(self):
+        self.assertEqual(current_app.config['BOOTSTRAP_BTN_SIZE'], 'md')
+        current_app.config['BOOTSTRAP_BTN_SIZE'] = 'lg'
+
+        @self.app.route('/form')
+        def test():
+            form = HelloForm()
+            return render_template_string('''
+            {% from 'bootstrap/form.html' import render_form %}
+            {{ render_form(form) }}
+            ''', form=form)
+
+        response = self.client.get('/form')
+        data = response.get_data(as_text=True)
+        self.assertIn('btn-lg', data)
+
+        @self.app.route('/form2')
+        def test_overwrite():
+            form = HelloForm()
+            return render_template_string('''
+            {% from 'bootstrap/form.html' import render_form %}
+            {{ render_form(form, button_size='sm') }}
+            ''', form=form)
+
+        response = self.client.get('/form2')
+        data = response.get_data(as_text=True)
+        self.assertNotIn('btn-lg', data)
+        self.assertIn('btn-sm', data)
+
+    def test_button_style(self):
+        self.assertEqual(current_app.config['BOOTSTRAP_BTN_STYLE'], 'secondary')
+        current_app.config['BOOTSTRAP_BTN_STYLE'] = 'primary'
+
+        @self.app.route('/form')
+        def test():
+            form = HelloForm()
+            return render_template_string('''
+            {% from 'bootstrap/form.html' import render_form %}
+            {{ render_form(form) }}
+            ''', form=form)
+
+        response = self.client.get('/form')
+        data = response.get_data(as_text=True)
+        self.assertIn('btn-primary', data)
+
+        @self.app.route('/form2')
+        def test_overwrite():
+            form = HelloForm()
+            return render_template_string('''
+            {% from 'bootstrap/form.html' import render_form %}
+            {{ render_form(form, button_style='success') }}
+            ''', form=form)
+
+        response = self.client.get('/form2')
+        data = response.get_data(as_text=True)
+        self.assertNotIn('btn-primary', data)
+        self.assertIn('btn-success', data)
+
+        @self.app.route('/form3')
+        def test_button_map():
+            form = HelloForm()
+            return render_template_string('''
+            {% from 'bootstrap/form.html' import render_form %}
+            {{ render_form(form, button_map={'submit': 'warning'}) }}
+            ''', form=form)
+
+        response = self.client.get('/form3')
+        data = response.get_data(as_text=True)
+        self.assertNotIn('btn-primary', data)
+        self.assertIn('btn-warning', data)


### PR DESCRIPTION
Add `button_size` and `button_style` for `render_field` and `render_form` macro, this will overwrite the default value set by config `BOOTSTRAP_BTN_SIZE` and `BOOTSTRAP_BTN_STYLE`.

Todo

- [x] Source
- [x] Example Application
- [x] Docs
- [x] Test
- [x] Changelog