### PR TITLE
Update to JQuery 3.4.1 for security updates

### DIFF
--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -20,7 +20,7 @@ else:
 
 # central definition of used versions
 VERSION_BOOTSTRAP = '4.3.1'
-VERSION_JQUERY = '3.3.1'
+VERSION_JQUERY = '3.4.1'
 VERSION_POPPER = '1.14.0'
 
 


### PR DESCRIPTION
Simple update to JQuery.

Plesae don't use 3.5.0.
See: https://stackoverflow.com/questions/61177140/uncaught-typeerror-cannot-convert-object-to-primitive-valuezone-evergreen-js1/61177704#61177704