### PR TITLE
Typo in install instructions

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -16,7 +16,7 @@ Flask-Bootstrap first and then install Bootstra-Flask:
 .. code-block:: bash
 
     $ pip uninstall flask-bootstrap
-    $ pip install bootstap-flask
+    $ pip install bootstrap-flask
 
 if you accidently installed both of them, you will need to uninstall them both first:
 


### PR DESCRIPTION
Following the current migration installations fails due to a typo in the package name.

Ends in : `requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://pypi.org/simple/bootstap-flask/`