### PR TITLE
supply titles to render_table

### DIFF
--- a/examples/templates/table.html
+++ b/examples/templates/table.html
@@ -4,7 +4,7 @@
 {% block content %}
 <h2>Simple Table</h2>
 <pre>{% raw %}{{ render_table(messages) }}{% endraw %}</pre>
-{{ render_table(messages) }}
+{{ render_table(messages, titles) }}
 
 <h2>Cutomized Table</h2>
 <pre>{% raw %}{{ render_table(messages, titles, table_classes='table-striped', header_classes='thead-dark', caption='Messages') }}{% endraw %}</pre>
@@ -12,14 +12,14 @@
 
 <h2>Responsive Table</h2>
 <pre>{% raw %}{{ render_table(messages, responsive=True, responsive_class='table-responsive-sm') }}{% endraw %}</pre>
-{{ render_table(messages, responsive=True, responsive_class='table-responsive-sm') }}
+{{ render_table(messages, titles, responsive=True, responsive_class='table-responsive-sm') }}
 
 <h2>Table with actions</h2>
 <pre>{% raw %}{{ render_table(messages, show_actions=True,
                 view_url=url_for('view_message', message_id=':primary_key'),
                 edit_url=url_for('edit_message', message_id=':primary_key'),
                 delete_url=url_for('delete_message', message_id=':primary_key')) }}{% endraw %}</pre>
-{{ render_table(messages, show_actions=True,
+{{ render_table(messages, titles, show_actions=True,
                 view_url=url_for('view_message', message_id=':primary_key'),
                 edit_url=url_for('edit_message', message_id=':primary_key'),
                 delete_url=url_for('delete_message', message_id=':primary_key')) }}


### PR DESCRIPTION
Rendering of /table fails with a  Internal Server Error because `titles` isn't passed on the `render_table(messages, titles)`.

Origin of the error:
https://github.com/greyli/bootstrap-flask/blob/04c023601ce875b7ad38aa26957a4302123551f4/flask_bootstrap/templates/bootstrap/table.html#L17 