### PR TITLE
Add new_url parameter for render_table macro

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.6.0
+-----
+
+- Add ``new_url`` parameter for ``render_table`` macro. When passing an URL to the ``new_url`` parameter,
+the ``render_table`` macro will create a icon (link) on the action header.
+
 
 1.5.3
 -----

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -436,6 +436,7 @@ API
                               view_url=None,\
                               edit_url=None,\
                               delete_url=None,\
+                              new_url=None,\
                               action_pk_placeholder=':primary_key')
 
     :param data: An iterable of data objects to render. Can be dicts or class objects.
@@ -453,6 +454,7 @@ API
     :param view_url: URL to use for the view action.
     :param edit_url: URL to use for the edit action.
     :param delete_url: URL to use for the delete action.
+    :param new_url: URL to use for the create action (new in version 1.6.0).
     :param action_pk_placeholder: The placeholder which replaced by the primary key when build the action URLs. Default is ``':primary_key'``.
 
 

--- a/examples/app.py
+++ b/examples/app.py
@@ -177,6 +177,11 @@ def delete_message(message_id):
     return f'Message {message_id} did not exist and could therefore not be deleted. Return to <a href="/table">table</a>.'
 
 
+@app.route('/table/new-message')
+def new_message():
+    return 'Here is the new message page. Return to <a href="/table">table</a>.'
+
+
 @app.route('/icon')
 def test_icon():
     return render_template('icon.html')

--- a/examples/templates/table.html
+++ b/examples/templates/table.html
@@ -22,5 +22,6 @@
 {{ render_table(messages, show_actions=True,
                 view_url=url_for('view_message', message_id=':primary_key'),
                 edit_url=url_for('edit_message', message_id=':primary_key'),
-                delete_url=url_for('delete_message', message_id=':primary_key')) }}
+                delete_url=url_for('delete_message', message_id=':primary_key'),
+                new_url=url_for('new_message')) }}
 {% endblock %}

--- a/flask_bootstrap/static/img/new.svg
+++ b/flask_bootstrap/static/img/new.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-circle-fill" viewBox="0 0 16 16">
+  <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8.5 4.5a.5.5 0 0 0-1 0v3h-3a.5.5 0 0 0 0 1h3v3a.5.5 0 0 0 1 0v-3h3a.5.5 0 0 0 0-1h-3v-3z"/>
+</svg>

--- a/flask_bootstrap/templates/bootstrap/table.html
+++ b/flask_bootstrap/templates/bootstrap/table.html
@@ -12,6 +12,7 @@
                       view_url=None,
                       edit_url=None,
                       delete_url=None,
+                      new_url=None,
                       action_pk_placeholder=':primary_key') %}
   {% if not titles %}
     {% set titles = get_table_titles(data, primary_key, primary_key_title) %}
@@ -29,7 +30,9 @@
       <th scope="col">{{ title[1] }}</th>
     {% endfor %}
     {% if show_actions %}
-      <th scope="col">{{ actions_title }}</th>
+      <th scope="col">{{ actions_title }}
+        {%if new_url %}<a href="{{ new_url }}"><img src="{{ url_for('bootstrap.static', filename='img/new.svg') }}" alt="New"></a>{% endif %}
+      </th>
     {% endif %}
   </tr>
   </thead>

--- a/tests/test_render_table.py
+++ b/tests/test_render_table.py
@@ -152,6 +152,10 @@ class TestPagination:
         def test_view_message(message_id):
             return 'Viewing {}'.format(message_id)
 
+        @app.route('/table/new-message')
+        def test_create_message():
+            return 'New message'
+
         @app.route('/table')
         def test():
             db.drop_all()
@@ -167,10 +171,12 @@ class TestPagination:
             return render_template_string('''
                                     {% from 'bootstrap/table.html' import render_table %}
                                     {{ render_table(messages, titles, show_actions=True,
-                                    view_url=url_for('test_view_message', message_id=':primary_key')) }}
+                                    view_url=url_for('test_view_message', message_id=':primary_key'),
+                                    new_url=url_for('test_create_message')) }}
                                     ''', titles=titles, messages=messages)
 
         response = client.get('/table')
         data = response.get_data(as_text=True)
         assert '<a href="/table/1/view">' in data
-        assert '<img src="/bootstrap/static/img/view.svg" alt="View">' in data
+        assert '<a href="/table/new-message">' in data
+        assert '<img src="/bootstrap/static/img/new.svg" alt="New">' in data


### PR DESCRIPTION
fixes #128

Example:

```jinja2
{{ render_table(messages, show_actions=True, ..., new_url=url_for('new_message')) }}
```

The output will like this:

![image](https://user-images.githubusercontent.com/12967000/120064056-07e86000-c09d-11eb-85d2-00f1c8989dc2.png)
