### PR TITLE
Added custom_actions functionality to render_table macro

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,9 @@ Release date: -
 1.6.1
 -----
 
-Release date: -
+Release date: 2021/6/2
+
+- Add a ``custom_actions`` parameter for the ``render_table`` macro. When passing a list of tuples ```[(title, bootstrap icon, link)]``` to the ``custom_actions`` parameter, the ``render_table`` macro will create an icon (link) on the action header for each tuple in the list. The title text (first index of each tuple) will show when hovering over each ``custom_actions`` button.
 
 
 1.6.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Release date: -
 1.6.1
 -----
 
-Release date: 2021/6/2
+Release date: -
 
 - Add a ``custom_actions`` parameter for the ``render_table`` macro. When passing a list of tuples ``[(title, bootstrap icon, link)]`` to the ``custom_actions`` parameter, the ``render_table`` macro will create an icon (link) on the action header for each tuple in the list. The title text (first index of each tuple) will show when hovering over each ``custom_actions`` button.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Release date: -
 
 Release date: 2021/6/2
 
-- Add a ``custom_actions`` parameter for the ``render_table`` macro. When passing a list of tuples ```[(title, bootstrap icon, link)]``` to the ``custom_actions`` parameter, the ``render_table`` macro will create an icon (link) on the action header for each tuple in the list. The title text (first index of each tuple) will show when hovering over each ``custom_actions`` button.
+- Add a ``custom_actions`` parameter for the ``render_table`` macro. When passing a list of tuples ``[(title, bootstrap icon, link)]`` to the ``custom_actions`` parameter, the ``render_table`` macro will create an icon (link) on the action header for each tuple in the list. The title text (first index of each tuple) will show when hovering over each ``custom_actions`` button.
 
 
 1.6.0

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -433,6 +433,7 @@ API
                               responsive_class='table-responsive',\
                               show_actions=False,\
                               actions_title='Actions',\
+                              custom_actions=None,\
                               view_url=None,\
                               edit_url=None,\
                               delete_url=None,\
@@ -451,6 +452,9 @@ API
     :param responsive_class: The responsive class to apply to the table. Default is ``'table-responsive'``.
     :param show_actions: Whether to display the actions column. Default is ``False``.
     :param actions_title: Title for the actions column header. Default is ``'Actions'``.
+    :param custom_actions: A list of tuples for creating custom action buttons, where each tuple contains
+                ('Title Text displayed on hover', 'bootstrap icon name', 'url_for()')
+                (e.g.``[('Run', 'play-fill', url_for('run_report', report_id=':primary_key'))]``).
     :param view_url: URL to use for the view action.
     :param edit_url: URL to use for the edit action.
     :param delete_url: URL to use for the delete action.

--- a/flask_bootstrap/templates/bootstrap/table.html
+++ b/flask_bootstrap/templates/bootstrap/table.html
@@ -9,6 +9,7 @@
                       responsive_class='table-responsive',
                       show_actions=False,
                       actions_title='Actions',
+                      custom_actions=None,
                       view_url=None,
                       edit_url=None,
                       delete_url=None,
@@ -37,6 +38,9 @@
   </tr>
   </thead>
   <tbody>
+  {% if custom_actions %}
+    {% from 'bootstrap/utils.html' import render_icon %}
+  {% endif %}
   {% for row in data %}
     <tr>
       {% for title in titles %}
@@ -48,6 +52,14 @@
       {% endfor %}
       {% if show_actions %}
         <td>
+          {% if custom_actions %}
+            {% for (action_name, action_icon, action_url) in custom_actions %}
+                <a style="font-size: 18px;" 
+                   class="text-dark text-decoration-none" 
+                   href="{{ action_url | replace(action_pk_placeholder, row[primary_key]) }}" 
+                   title="{{ action_name }}">{{ render_icon(action_icon) }}</a>
+            {% endfor %}
+          {% endif %}
           {% if view_url %}
             <a href="{{ view_url | replace(action_pk_placeholder, row[primary_key]) }}"><img src="{{ url_for('bootstrap.static', filename='img/view.svg') }}" alt="View"></a>
           {% endif %}

--- a/tests/test_render_table.py
+++ b/tests/test_render_table.py
@@ -147,6 +147,10 @@ class TestPagination:
         class Message(db.Model):
             id = db.Column(db.Integer, primary_key=True)
             text = db.Column(db.Text)
+            
+        @app.route('/table/<message_id>/resend')
+        def test_resend_message(message_id):
+            return 'Re-sending {}'.format(message_id)
 
         @app.route('/table/<message_id>/view')
         def test_view_message(message_id):

--- a/tests/test_render_table.py
+++ b/tests/test_render_table.py
@@ -183,7 +183,8 @@ class TestPagination:
         response = client.get('/table')
         data = response.get_data(as_text=True)
         assert 'icons/bootstrap-icons.svg#bootstrap-reboot' in data
-        assert 'href="/table/1/resend" title="Resend">' in data
+        assert 'href="/table/1/resend"' in data
+        assert 'title="Resend">' in data
         assert '<a href="/table/1/view">' in data
         assert '<a href="/table/new-message">' in data
         assert '<img src="/bootstrap/static/img/new.svg" alt="New">' in data

--- a/tests/test_render_table.py
+++ b/tests/test_render_table.py
@@ -147,7 +147,7 @@ class TestPagination:
         class Message(db.Model):
             id = db.Column(db.Integer, primary_key=True)
             text = db.Column(db.Text)
-            
+
         @app.route('/table/<message_id>/resend')
         def test_resend_message(message_id):
             return 'Re-sending {}'.format(message_id)
@@ -173,12 +173,12 @@ class TestPagination:
             messages = pagination.items
             titles = [('id', '#'), ('text', 'Message')]
             return render_template_string('''
-                                    {% from 'bootstrap/table.html' import render_table %}
-                                    {{ render_table(messages, titles, show_actions=True,
-                                    custom_actions=[('Resend', 'bootstrap-reboot', url_for('test_resend_message', message_id=':primary_key'))], 
-                                    view_url=url_for('test_view_message', message_id=':primary_key'),
-                                    new_url=url_for('test_create_message')) }}
-                                    ''', titles=titles, messages=messages)
+                {% from 'bootstrap/table.html' import render_table %}
+                {{ render_table(messages, titles, show_actions=True,
+                custom_actions=[('Resend', 'bootstrap-reboot', url_for('test_resend_message', message_id=':primary_key'))],
+                view_url=url_for('test_view_message', message_id=':primary_key'),
+                new_url=url_for('test_create_message')) }}
+            ''', titles=titles, messages=messages)
 
         response = client.get('/table')
         data = response.get_data(as_text=True)

--- a/tests/test_render_table.py
+++ b/tests/test_render_table.py
@@ -171,12 +171,15 @@ class TestPagination:
             return render_template_string('''
                                     {% from 'bootstrap/table.html' import render_table %}
                                     {{ render_table(messages, titles, show_actions=True,
+                                    custom_actions=[('Resend', 'bootstrap-reboot', url_for('test_resend_message', message_id=':primary_key'))], 
                                     view_url=url_for('test_view_message', message_id=':primary_key'),
                                     new_url=url_for('test_create_message')) }}
                                     ''', titles=titles, messages=messages)
 
         response = client.get('/table')
         data = response.get_data(as_text=True)
+        assert 'icons/bootstrap-icons.svg#bootstrap-reboot' in data
+        assert 'href="/table/1/resend" title="Resend">' in data
         assert '<a href="/table/1/view">' in data
         assert '<a href="/table/new-message">' in data
         assert '<img src="/bootstrap/static/img/new.svg" alt="New">' in data

--- a/tests/test_render_table.py
+++ b/tests/test_render_table.py
@@ -175,7 +175,9 @@ class TestPagination:
             return render_template_string('''
                 {% from 'bootstrap/table.html' import render_table %}
                 {{ render_table(messages, titles, show_actions=True,
-                custom_actions=[('Resend', 'bootstrap-reboot', url_for('test_resend_message', message_id=':primary_key'))],
+                custom_actions=[
+                    ('Resend', 'bootstrap-reboot', url_for('test_resend_message', message_id=':primary_key'))
+                ],
                 view_url=url_for('test_view_message', message_id=':primary_key'),
                 new_url=url_for('test_create_message')) }}
             ''', titles=titles, messages=messages)


### PR DESCRIPTION
`custom_actions` accepts a list of tuples where a tuple should contain 3 items:
1. The button's title (what shows on hover)
2. The bootstrap icon name to render (via `render_icon` macro)
3. The `url_for()` link in the same format as the other action urls

Since the new parameter logic requires the `render_icon` macro, I've added the conditional import logic right before the table data for-loop.

**Example Usage:**
```
{{ render_table(
       report_list,
       titles=headers,
       responsive=True,
       show_actions=True,
       custom_actions=[('Run', 'play-fill', url_for('run_report', report_id=':primary_key'))],
       view_url=url_for('view_report', report_id=':primary_key'),
       edit_url=url_for('update_report', report_id=':primary_key'),
       delete_url=url_for('delete_report', report_id=':primary_key')
) }}
```

**Result:**
![image](https://user-images.githubusercontent.com/22151742/120350027-9989e480-c2cc-11eb-8429-3802ac03dc7a.png)

I'm not sure what would be more desirable in terms of custom_action button placement, but I decided to have the custom buttons render *before* the other actions. Let me know if you'd like me to move them to the end after the other actions.