### PR TITLE
Improve table action URLs handling

### DIFF
--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -24,6 +24,10 @@ VERSION_JQUERY = '3.4.1'
 VERSION_POPPER = '1.14.0'
 
 
+def raise_helper(message):
+    raise RuntimeError(message)
+
+
 def get_table_titles(data, primary_key, primary_key_title):
     """Detect and build the table titles tuple from ORM object, currently only support SQLAlchemy.
 
@@ -58,6 +62,7 @@ class Bootstrap(object):
         app.jinja_env.globals['bootstrap_is_hidden_field'] = is_hidden_field_filter
         app.jinja_env.globals['get_table_titles'] = get_table_titles
         app.jinja_env.globals['warn'] = warnings.warn
+        app.jinja_env.globals['raise'] = raise_helper
         app.jinja_env.add_extension('jinja2.ext.do')
         # default settings
         app.config.setdefault('BOOTSTRAP_SERVE_LOCAL', False)

--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -24,7 +24,7 @@ VERSION_JQUERY = '3.4.1'
 VERSION_POPPER = '1.14.0'
 
 
-def raise_helper(message):
+def raise_helper(message):  # pragma: no cover
     raise RuntimeError(message)
 
 

--- a/flask_bootstrap/templates/bootstrap/table.html
+++ b/flask_bootstrap/templates/bootstrap/table.html
@@ -1,14 +1,10 @@
 {% from 'bootstrap/utils.html' import render_icon, arg_url_for %}
 
-{% macro deprecate_old_pk_placeholder() %}
-    {{ warn('The default action primary key placeholder has changed to ":id", please update. The support to the old value (":primary_key") will be removed in version 2.0.') }}
+{% macro deprecate_placeholder_url() %}
+    {{ warn('Passing an URL with primary key palceholder for view_url/edit_url/delete_url/custom_actions is deprecated. You will need to pass an fixed URL or an URL tuple to URL arguments, see the API docs of render_table for more details. The support to URL string will be removed in version 2.0.') }}
 {% endmacro %}
 
-{% macro deprecate_action_url_string() %}
-    {{ warn('Passing an string as action URL for view_url/edit_url/delete_url/custom_actions is deprecated. You will need to pass an URL tuple to URL arguments, see the API docs of render_table for more details. The support to URL string will be removed in version 2.0.') }}
-{% endmacro %}
-
-{% macro build_url(endpoint, model, pk, kwargs) %}
+{% macro build_url(endpoint, model, pk, url_tuples) %}
     {% if model == None %}
         {{ raise("The model argument can't be None when setting action URLs.") }}
     {% endif %}
@@ -16,15 +12,15 @@
         {%- do url_params.update(request.view_args if not endpoint else {}),
             url_params.update(request.args if not endpoint else {}) -%}
         {% with record = model.query.get(pk) %}
-            {% for kwarg, value in kwargs %}
-                {% if value.startswith(':') and '.' in value %}
-                    {%- set value = value[1:].split('.') -%}
-                    {%- do url_params.update({kwarg: record[value[0]][value[1]]}) -%}
-                {% elif value.startswith(':') %}
-                    {%- set value = value[1:] -%}
-                    {%- do url_params.update({kwarg: record[value]}) -%}
+            {% for url_parameter, db_field in url_tuples %}
+                {% if db_field.startswith(':') and '.' in db_field %}
+                    {%- set db_field = db_field[1:].split('.') -%}
+                    {%- do url_params.update({url_parameter: record[db_field[0]][db_field[1]]}) -%}
+                {% elif db_field.startswith(':') %}
+                    {%- set db_field = db_field[1:] -%}
+                    {%- do url_params.update({url_parameter: record[db_field]}) -%}
                 {% else %}
-                    {%- do url_params.update({kwarg: value}) -%}
+                    {%- do url_params.update({url_parameter: db_field}) -%}
                 {% endif %}
             {% endfor %}
         {% endwith -%}
@@ -98,11 +94,10 @@
             {% for (action_name, action_icon, action_url) in custom_actions %}
                 {% if ':primary_key' in action_url | join('') %}
                     {% set action_pk_placeholder = ':primary_key' %}
-                    {% set w = deprecate_old_pk_placeholder() %}
+                    {% set _ = deprecate_placeholder_url() %}
                 {% endif %}
                 <a class="action-icon text-decoration-none"
                    {% if action_url is string %}
-                   {% set w = deprecate_action_url_string() %}
                     href="{{ action_url | replace(action_pk_placeholder, row[primary_key]) }}"
                    {% else %}
                     href="{{ build_url(action_url[0], model, row[primary_key], action_url[1]) | trim }}"
@@ -113,11 +108,10 @@
             {% if view_url %}
                 {% if ':primary_key' in view_url | join('') %}
                     {% set action_pk_placeholder = ':primary_key' %}
-                    {% set w = deprecate_old_pk_placeholder() %}
+                    {% set _ = deprecate_placeholder_url() %}
                 {% endif %}
                 <a class="action-icon text-decoration-none"
                    {% if view_url is string %}
-                   {% set w = deprecate_action_url_string() %}
                     href="{{ view_url | replace(action_pk_placeholder, row[primary_key]) }}"
                    {% else %}
                     href="{{ build_url(view_url[0], model, row[primary_key], view_url[1]) | trim }}"
@@ -129,11 +123,10 @@
             {% if edit_url -%}
                 {% if ':primary_key' in edit_url | join('') %}
                     {% set action_pk_placeholder = ':primary_key' %}
-                    {% set w = deprecate_old_pk_placeholder() %}
+                    {% set w = deprecate_placeholder_url() %}
                 {% endif %}
                 <a class="action-icon text-decoration-none"
                    {% if edit_url is string %}
-                   {% set w = deprecate_action_url_string() %}
                     href="{{ edit_url | replace(action_pk_placeholder, row[primary_key]) }}"
                    {% else %}
                     href="{{ build_url(edit_url[0], model, row[primary_key], edit_url[1]) | trim }}"
@@ -145,11 +138,10 @@
             {% if delete_url %}
                 {% if ':primary_key' in delete_url | join('') %}
                     {% set action_pk_placeholder = ':primary_key' %}
-                    {% set w = deprecate_old_pk_placeholder() %}
+                    {% set _ = deprecate_placeholder_url() %}
                 {% endif %}
             <form style="display:inline"
                   {% if delete_url is string %}
-                  {% set w = deprecate_action_url_string() %}
                    action="{{ delete_url | replace(action_pk_placeholder, row[primary_key]) }}"
                   {% else %}
                    action="{{ build_url(delete_url[0], model, row[primary_key], delete_url[1]) | trim }}"

--- a/flask_bootstrap/templates/bootstrap/table.html
+++ b/flask_bootstrap/templates/bootstrap/table.html
@@ -102,48 +102,48 @@
             {% endfor %}
             {% endif %}
             {% if view_url %}
-                {% if ':primary_key' in view_url|join('') %}
+                {% if ':primary_key' in view_url | join('') %}
                     {% set action_pk_placeholder = ':primary_key' %}
                     {% set w = deprecate_old_pk_placeholder() %}
                 {% endif %}
                 <a class="action-icon text-decoration-none"
                    {% if view_url is string %}
                    {% set w = deprecate_action_url_string() %}
-                    href="{{ view_url }}"
+                    href="{{ view_url | replace(action_pk_placeholder, row[primary_key]) }}"
                    {% else %}
-                    href="{{ build_url(view_url[0], model, row[primary_key], view_url[1])|trim }}"
+                    href="{{ build_url(view_url[0], model, row[primary_key], view_url[1]) | trim }}"
                    {% endif %}
                     title="{{ config['BOOTSTRAP_TABLE_VIEW_TITLE'] }}">
                     {{ render_icon('eye-fill') }}
                 </a>
             {% endif %}
             {% if edit_url -%}
-                {% if ':primary_key' in edit_url|join('') %}
+                {% if ':primary_key' in edit_url | join('') %}
                     {% set action_pk_placeholder = ':primary_key' %}
                     {% set w = deprecate_old_pk_placeholder() %}
                 {% endif %}
                 <a class="action-icon text-decoration-none"
                    {% if edit_url is string %}
                    {% set w = deprecate_action_url_string() %}
-                    href="{{ edit_url }}"
+                    href="{{ edit_url | replace(action_pk_placeholder, row[primary_key]) }}"
                    {% else %}
-                    href="{{ build_url(edit_url[0], model, row[primary_key], edit_url[1])|trim }}"
+                    href="{{ build_url(edit_url[0], model, row[primary_key], edit_url[1]) | trim }}"
                    {% endif %}
                     title="{{ config['BOOTSTRAP_TABLE_EDIT_TITLE'] }}">
                     {{ render_icon('pencil-fill') }}
                 </a>
             {%- endif %}
             {% if delete_url %}
-                {% if ':primary_key' in delete_url|join('') %}
+                {% if ':primary_key' in delete_url | join('') %}
                     {% set action_pk_placeholder = ':primary_key' %}
                     {% set w = deprecate_old_pk_placeholder() %}
                 {% endif %}
             <form style="display:inline"
                   {% if delete_url is string %}
                   {% set w = deprecate_action_url_string() %}
-                   action="{{ delete_url }}"
+                   action="{{ delete_url | replace(action_pk_placeholder, row[primary_key]) }}"
                   {% else %}
-                   action="{{ build_url(delete_url[0], model, row[primary_key], delete_url[1])|trim }}"
+                   action="{{ build_url(delete_url[0], model, row[primary_key], delete_url[1]) | trim }}"
                   {% endif %}
                    method="post">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/flask_bootstrap/templates/bootstrap/table.html
+++ b/flask_bootstrap/templates/bootstrap/table.html
@@ -5,7 +5,7 @@
 {% endmacro %}
 
 {% macro deprecate_action_url_string() %}
-    {{ warn('Passing an string as action URL is deprecated. You will need to pass an URL tuple to URL arguments, see the API docs of render_table for more details. The support to URL string will be removed in version 2.0.') }}
+    {{ warn('Passing an string as action URL for view_url/edit_url/delete_url/custom_actions is deprecated. You will need to pass an URL tuple to URL arguments, see the API docs of render_table for more details. The support to URL string will be removed in version 2.0.') }}
 {% endmacro %}
 
 {% macro build_url(endpoint, model, pk, kwargs) %}
@@ -68,8 +68,14 @@
     {% if show_actions %}
         <th scope="col">{{ actions_title }}
         {% if new_url %}
-            <a class="action-icon text-decoration-none" href="{{ new_url }}" title="{{ config['BOOTSTRAP_TABLE_NEW_TITLE'] }}">
-            {{ render_icon('plus-circle-fill') }}
+            <a class="action-icon text-decoration-none"
+                {% if new_url.startswith('/') %}
+                href="{{ new_url }}"
+                {% else %}
+                href="{{ url_for(new_url) }}"
+                {% endif %}
+                title="{{ config['BOOTSTRAP_TABLE_NEW_TITLE'] }}">
+                {{ render_icon('plus-circle-fill') }}
             </a>
         {% endif %}
         </th>

--- a/flask_bootstrap/templates/bootstrap/table.html
+++ b/flask_bootstrap/templates/bootstrap/table.html
@@ -1,8 +1,11 @@
 {% from 'bootstrap/utils.html' import render_icon, arg_url_for %}
 
 {% macro deprecate_old_pk_placeholder() %}
-    {{ warn('The default action primary key placeholder has changed to ":id", please update.
-        The support to the old value (":primary_key") will be removed in version 2.0.') }}
+    {{ warn('The default action primary key placeholder has changed to ":id", please update. The support to the old value (":primary_key") will be removed in version 2.0.') }}
+{% endmacro %}
+
+{% macro deprecate_action_url_string() %}
+    {{ warn('Passing an string as action URL is deprecated. You will need to pass an URL tuple to URL arguments, see the API docs of render_table for more details. The support to URL string will be removed in version 2.0.') }}
 {% endmacro %}
 
 {% macro build_url(endpoint, model, pk, kwargs) %}
@@ -90,6 +93,7 @@
                 {% endif %}
                 <a class="action-icon text-decoration-none"
                    {% if action_url is string %}
+                   {% set w = deprecate_action_url_string() %}
                     href="{{ action_url | replace(action_pk_placeholder, row[primary_key]) }}"
                    {% else %}
                     href="{{ build_url(action_url[0], model, row[primary_key], action_url[1]) | trim }}"
@@ -104,6 +108,7 @@
                 {% endif %}
                 <a class="action-icon text-decoration-none"
                    {% if view_url is string %}
+                   {% set w = deprecate_action_url_string() %}
                     href="{{ view_url }}"
                    {% else %}
                     href="{{ build_url(view_url[0], model, row[primary_key], view_url[1])|trim }}"
@@ -119,6 +124,7 @@
                 {% endif %}
                 <a class="action-icon text-decoration-none"
                    {% if edit_url is string %}
+                   {% set w = deprecate_action_url_string() %}
                     href="{{ edit_url }}"
                    {% else %}
                     href="{{ build_url(edit_url[0], model, row[primary_key], edit_url[1])|trim }}"
@@ -134,6 +140,7 @@
                 {% endif %}
             <form style="display:inline"
                   {% if delete_url is string %}
+                  {% set w = deprecate_action_url_string() %}
                    action="{{ delete_url }}"
                   {% else %}
                    action="{{ build_url(delete_url[0], model, row[primary_key], delete_url[1])|trim }}"

--- a/flask_bootstrap/templates/bootstrap/table.html
+++ b/flask_bootstrap/templates/bootstrap/table.html
@@ -9,6 +9,9 @@
 {% endmacro %}
 
 {% macro build_url(endpoint, model, pk, kwargs) %}
+    {% if model == None %}
+        {{ raise("The model argument can't be None when setting action URLs.") }}
+    {% endif %}
     {% with url_params = {} -%}
         {%- do url_params.update(request.view_args if not endpoint else {}),
             url_params.update(request.args if not endpoint else {}) -%}

--- a/tests/test_render_table.py
+++ b/tests/test_render_table.py
@@ -3,7 +3,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import CSRFProtect
 
 
-class TestPagination:
+class TestRenderTable:
     def test_render_simple_table(self, app, client):
         db = SQLAlchemy(app)
 
@@ -142,7 +142,81 @@ class TestPagination:
         response = client.get('/table')
         assert response.status_code == 200
 
-    def test_render_table_with_actions(self, app, client):
+    def test_render_table_with_actions(self, app, client):  # noqa: C901
+        app.jinja_env.globals['csrf_token'] = lambda: ''
+
+        db = SQLAlchemy(app)
+
+        class Message(db.Model):
+            id = db.Column(db.Integer, primary_key=True)
+            sender = db.Column(db.String(20))
+            recipient = db.Column(db.String(20))
+            text = db.Column(db.Text)
+
+        @app.route('/new-message')
+        def new_message():
+            return 'Create message'
+
+        @app.route('/messages/<message_id>/edit')
+        def edit_message(message_id):
+            return 'Editing message {}'.format(message_id)
+
+        @app.route('/messages/<message_id>/view')
+        def view_message(message_id):
+            return 'Viewing message {}'.format(message_id)
+
+        @app.route('/messages/<message_id>/delete')
+        def delete_message(message_id):
+            return 'Deleting message {}'.format(message_id)
+
+        @app.route('/messages/<message_id>/resend')
+        def resend_message(message_id):
+            return 'Re-sending message {}'.format(message_id)
+
+        @app.route('/table')
+        def test():
+            db.drop_all()
+            db.create_all()
+            for i in range(10):
+                m = Message(
+                    text='Test message {}'.format(i+1),
+                    sender='me',
+                    recipient='john_doe'
+                )
+                db.session.add(m)
+            db.session.commit()
+            page = request.args.get('page', 1, type=int)
+            pagination = Message.query.paginate(page, per_page=10)
+            messages = pagination.items
+            titles = [('id', '#'), ('text', 'Message')]
+            return render_template_string('''
+                {% from 'bootstrap/table.html' import render_table %}
+                # URL arguments with URL string (deprecated (except new_url), will be removed in 2.0)
+                {{ render_table(messages, titles, show_actions=True,
+                custom_actions=[
+                    (
+                        'Resend',
+                        'bootstrap-reboot',
+                        url_for('resend_message', message_id=':id')
+                    )
+                ],
+                view_url=url_for('view_message', message_id=':id'),
+                delete_url=url_for('delete_message', message_id=':id'),
+                edit_url=url_for('edit_message', message_id=':id'),
+                new_url=url_for('new_message')
+                ) }}
+            ''', titles=titles, model=Message, messages=messages)
+
+        response = client.get('/table')
+        data = response.get_data(as_text=True)
+        assert 'icons/bootstrap-icons.svg#bootstrap-reboot' in data
+        assert 'title="Resend">' in data
+        assert 'href="/messages/1/edit"' in data
+        assert 'href="/messages/1/view"' in data
+        assert 'action="/messages/1/delete"' in data
+        assert 'href="/new-message"' in data
+
+    def test_render_table_with_actions_and_url_tuple(self, app, client):  # noqa: C901
         app.jinja_env.globals['csrf_token'] = lambda: ''
 
         db = SQLAlchemy(app)
@@ -172,26 +246,6 @@ class TestPagination:
         @app.route('/table/new-message')
         def test_create_message():
             return 'New message'
-
-        @app.route('/new-message')
-        def new_message():
-            return 'Create message'
-
-        @app.route('/messages/<message_id>/edit')
-        def edit_message(message_id):
-            return 'Editing message {}'.format(message_id)
-
-        @app.route('/messages/<message_id>/view')
-        def view_message(message_id):
-            return 'Viewing message {}'.format(message_id)
-
-        @app.route('/messages/<message_id>/delete')
-        def delete_message(message_id):
-            return 'Deleting message {}'.format(message_id)
-
-        @app.route('/messages/<message_id>/resend')
-        def resend_message(message_id):
-            return 'Re-sending message'.format(message_id)
 
         @app.route('/table')
         def test():
@@ -225,21 +279,6 @@ class TestPagination:
                 delete_url=('test_delete_message', [('sender', ':sender'), ('message_id', ':id')]),
                 new_url=('test_create_message')
                 ) }}
-
-                # URL arguments with URL string (deprecated (except new_url), will be removed in 2.0)
-                {{ render_table(messages, titles, show_actions=True,
-                custom_actions=[
-                    (
-                        'Resend',
-                        'bootstrap-reboot',
-                        url_for('resend_message', message_id=':id')
-                    )
-                ],
-                view_url=url_for('view_message', message_id=':id'),
-                delete_url=url_for('delete_message', message_id=':id'),
-                edit_url=url_for('edit_message', message_id=':id'),
-                new_url=url_for('new_message')
-                ) }}
             ''', titles=titles, model=Message, messages=messages)
 
         response = client.get('/table')
@@ -251,10 +290,6 @@ class TestPagination:
         assert 'action="/table/me/1/delete"' in data
         assert 'href="/table/me/1/edit"' in data
         assert 'href="/table/new-message"' in data
-        assert 'href="/messages/1/edit"' in data
-        assert 'href="/messages/1/view"' in data
-        assert 'action="/messages/1/delete"' in data
-        assert 'href="/new-message"' in data
 
     def test_customize_icon_title_of_table_actions(self, app, client):
 

--- a/tests/test_render_table.py
+++ b/tests/test_render_table.py
@@ -163,6 +163,10 @@ class TestPagination:
         def test_create_message():
             return 'New message'
 
+        @app.route('/messages/<id>/edit')
+        def edit_message(id):
+            return 'Editing message {}'.format(id)
+
         @app.route('/table')
         def test():
             db.drop_all()
@@ -190,6 +194,7 @@ class TestPagination:
                     )
                 ],
                 view_url=('test_view_message', [('sender', ':sender'), ('message_id', ':id')]),
+                edit_url=url_for('edit_message', id=':id'),
                 new_url=url_for('test_create_message')) }}
             ''', titles=titles, model=Message, messages=messages)
 
@@ -199,6 +204,7 @@ class TestPagination:
         assert 'href="/table/john_doe/1/resend"' in data
         assert 'title="Resend">' in data
         assert 'href="/table/me/1/view"' in data
+        assert 'href="/messages/1/edit"' in data
         assert 'href="/table/new-message"' in data
 
     def test_customize_icon_title_of_table_actions(self, app, client):

--- a/tests/test_render_table.py
+++ b/tests/test_render_table.py
@@ -143,6 +143,8 @@ class TestPagination:
         assert response.status_code == 200
 
     def test_render_table_with_actions(self, app, client):
+        app.jinja_env.globals['csrf_token'] = lambda: ''
+
         db = SQLAlchemy(app)
 
         class Message(db.Model):
@@ -159,13 +161,37 @@ class TestPagination:
         def test_view_message(sender, message_id):
             return 'Viewing {} from {}'.format(message_id, sender)
 
+        @app.route('/table/<string:sender>/<int:message_id>/edit')
+        def test_edit_message(sender, message_id):
+            return 'Editing {} from {}'.format(message_id, sender)
+
+        @app.route('/table/<string:sender>/<int:message_id>/delete')
+        def test_delete_message(sender, message_id):
+            return 'Deleting {} from {}'.format(message_id, sender)
+
         @app.route('/table/new-message')
         def test_create_message():
             return 'New message'
 
-        @app.route('/messages/<id>/edit')
-        def edit_message(id):
-            return 'Editing message {}'.format(id)
+        @app.route('/new-message')
+        def new_message():
+            return 'Create message'
+
+        @app.route('/messages/<message_id>/edit')
+        def edit_message(message_id):
+            return 'Editing message {}'.format(message_id)
+
+        @app.route('/messages/<message_id>/view')
+        def view_message(message_id):
+            return 'Viewing message {}'.format(message_id)
+
+        @app.route('/messages/<message_id>/delete')
+        def delete_message(message_id):
+            return 'Deleting message {}'.format(message_id)
+
+        @app.route('/messages/<message_id>/resend')
+        def resend_message(message_id):
+            return 'Re-sending message'.format(message_id)
 
         @app.route('/table')
         def test():
@@ -185,6 +211,7 @@ class TestPagination:
             titles = [('id', '#'), ('text', 'Message')]
             return render_template_string('''
                 {% from 'bootstrap/table.html' import render_table %}
+                # URL arguments with URL tuple
                 {{ render_table(messages, titles, model=model, show_actions=True,
                 custom_actions=[
                     (
@@ -194,8 +221,25 @@ class TestPagination:
                     )
                 ],
                 view_url=('test_view_message', [('sender', ':sender'), ('message_id', ':id')]),
-                edit_url=url_for('edit_message', id=':id'),
-                new_url=url_for('test_create_message')) }}
+                edit_url=('test_edit_message', [('sender', ':sender'), ('message_id', ':id')]),
+                delete_url=('test_delete_message', [('sender', ':sender'), ('message_id', ':id')]),
+                new_url=('test_create_message')
+                ) }}
+
+                # URL arguments with URL string (deprecated (except new_url), will be removed in 2.0)
+                {{ render_table(messages, titles, show_actions=True,
+                custom_actions=[
+                    (
+                        'Resend',
+                        'bootstrap-reboot',
+                        url_for('resend_message', message_id=':id')
+                    )
+                ],
+                view_url=url_for('view_message', message_id=':id'),
+                delete_url=url_for('delete_message', message_id=':id'),
+                edit_url=url_for('edit_message', message_id=':id'),
+                new_url=url_for('new_message')
+                ) }}
             ''', titles=titles, model=Message, messages=messages)
 
         response = client.get('/table')
@@ -204,8 +248,13 @@ class TestPagination:
         assert 'href="/table/john_doe/1/resend"' in data
         assert 'title="Resend">' in data
         assert 'href="/table/me/1/view"' in data
-        assert 'href="/messages/1/edit"' in data
+        assert 'action="/table/me/1/delete"' in data
+        assert 'href="/table/me/1/edit"' in data
         assert 'href="/table/new-message"' in data
+        assert 'href="/messages/1/edit"' in data
+        assert 'href="/messages/1/view"' in data
+        assert 'action="/messages/1/delete"' in data
+        assert 'href="/new-message"' in data
 
     def test_customize_icon_title_of_table_actions(self, app, client):
 


### PR DESCRIPTION
Continues #146 

- [x] Deprecate URL string for render_table URL arguments
- [x] Fix URL string support for view_url, edit_url and delete_url
- [x] Raise RuntimeError if model is None when setting table action URLs
- [x] Support passing URL tuple to render_table new_url
- [x] Improve tests for table action URLs
- [x] Update docs and changelog
- [ ] Update example application (when a new version is out)