### PR TITLE
Remove redundant space in breadcrumb macro

### DIFF
--- a/flask_bootstrap/templates/bootstrap/nav.html
+++ b/flask_bootstrap/templates/bootstrap/nav.html
@@ -9,7 +9,7 @@
 
 {% macro render_breadcrumb_item(endpoint, text) %}
     {% set active = True if request.endpoint and request.endpoint == endpoint else False %}
-    <li class="breadcrumb-item {% if active %}active{% endif %}" {% if active %} aria-current="page"{% endif %}>
+    <li class="breadcrumb-item {% if active %}active{% endif %}" {% if active %}aria-current="page"{% endif %}>
         {% if active %}
             {{ text }}
         {% else %}

--- a/tests/test_render_breadcrumb_item.py
+++ b/tests/test_render_breadcrumb_item.py
@@ -11,4 +11,4 @@ def test_render_breadcrumb_item(app, client):
 
     response = client.get('/breadcrumb_item')
     data = response.get_data(as_text=True)
-    assert '<li class="breadcrumb-item active"  aria-current="page">' in data
+    assert '<li class="breadcrumb-item active" aria-current="page">' in data


### PR DESCRIPTION
Fix #150 