### PR TITLE
Combine class arguments of render_field with Bootstrap classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changelog
 Release date: -
 
 - Drop Python 2 and 3.5 support.
+- Combine ``class`` argument of ``render_field`` or ``field.render_kw.class`` with Bootstrap classes
+   (`#159 <https://github.com/greyli/bootstrap-flask/pull/159>`__).
 
 
 1.8.0

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -81,6 +81,24 @@ Example
         {{ render_field(form.submit) }}
     </form>
 
+You can pass any HTTP attributes as extra keyword arguements like ``class`` or ``placeholder``:
+
+.. code-block:: jinja
+
+    {% from 'bootstrap/form.html' import render_field %}
+
+    <form method="post">
+        {{ form.csrf_token() }}
+        {{ render_field(form.username, class='myClass') }}
+        {{ render_field(form.password, placeholder='Your Password') }}
+        {{ render_field(form.submit) }}
+    </form>
+
+Notice the ``class`` value here will overwrite the ``render_kw={'class': '...'}`` you defined in
+the form class. Bootstrap-Flask will combine the class value you passed with the ``class`` key of
+the ``render_kw`` dict or the ``class`` keyword argments with Bootstrap classes.
+
+
 API
 ~~~~
 

--- a/flask_bootstrap/templates/bootstrap/form.html
+++ b/flask_bootstrap/templates/bootstrap/form.html
@@ -68,12 +68,13 @@ the necessary fix for required=False attributes, but will also not set the requi
     {% set extra_classes = render_kw_class + class %}
 
     {% if field.widget.input_type == 'checkbox' %}
+        {% set field_kwargs = kwargs %}
         {% call _hz_form_wrap(horizontal_columns, form_type, True, required=required) %}
             <div class="form-group form-check{% if form_type == "inline" %} form-check-inline{% endif %}">
                 {%- if field.errors %}
-                    {{ field(class="form-check-input is-invalid%s" % extra_classes)|safe }}
+                    {{ field(class="form-check-input is-invalid%s" % extra_classes, **field_kwargs)|safe }}
                 {%- else -%}
-                    {{ field(class="form-check-input%s" % extra_classes)|safe }}
+                    {{ field(class="form-check-input%s" % extra_classes, **field_kwargs)|safe }}
                 {%- endif %}
                 {{ field.label(class="form-check-label", for=field.id)|safe }}
                 {%- if field.errors %}

--- a/flask_bootstrap/templates/bootstrap/form.html
+++ b/flask_bootstrap/templates/bootstrap/form.html
@@ -56,7 +56,16 @@ the necessary fix for required=False attributes, but will also not set the requi
         {% set kwargs = dict(required=True, **kwargs) %}
     {% endif %}
 
-    {% set extra_classes = ' ' + field.render_kw.class if field.render_kw.class else '' %}
+    {# combine render_kw class or class/class_ argument with Bootstrap classes #}
+    {% set render_kw_class = ' ' + field.render_kw.class if field.render_kw.class else '' %}
+    {% set class = kwargs.pop('class', '') or kwargs.pop('class_', '') %}
+    {% if class %}
+        {# override render_kw class when class/class_ presents as keyword argument #}
+        {% set render_kw_class = '' %}
+        {% set render_kw_class_ = '' %}
+        {% set class = ' ' + class %}
+    {% endif %}
+    {% set extra_classes = render_kw_class + class %}
 
     {% if field.widget.input_type == 'checkbox' %}
         {% call _hz_form_wrap(horizontal_columns, form_type, True, required=required) %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from wtforms.validators import DataRequired, Length
 
 
 class HelloForm(FlaskForm):
-    name = StringField('Name')  
+    name = StringField('Name')
     username = StringField('Username', validators=[DataRequired(), Length(1, 20)])
     password = PasswordField('Password', validators=[DataRequired(), Length(8, 150)])
     remember = BooleanField('Remember me')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from wtforms.validators import DataRequired, Length
 
 
 class HelloForm(FlaskForm):
+    name = StringField('Name')  
     username = StringField('Username', validators=[DataRequired(), Length(1, 20)])
     password = PasswordField('Password', validators=[DataRequired(), Length(8, 150)])
     remember = BooleanField('Remember me')

--- a/tests/test_render_field.py
+++ b/tests/test_render_field.py
@@ -21,7 +21,7 @@ def test_render_field(app, client, hello_form):
     assert '<input class="form-control" id="password" name="password"' in data
 
 
-def test_render_field_with_classes(app, client, hello_form):
+def test_render_field_with_render_kw_classes(app, client, hello_form):
     @app.route('/render_kw_class')
     def test_render_kw_class():
         form = hello_form()
@@ -37,11 +37,12 @@ def test_render_field_with_classes(app, client, hello_form):
 
     response = client.get('/render_kw_class')
     data = response.get_data(as_text=True)
-    print(data)
     assert '<input class="form-control render_kw_class" id="name" name="name"' in data
     assert '<input class="form-control test" id="username" name="username"' in data
     assert '<input class="form-control test" id="password" name="password"' in data
 
+
+def test_render_field_with_kwargs(app, client, hello_form):
     @app.route('/kwargs_class')
     def test_kwargs_class():
         form = hello_form()
@@ -53,6 +54,23 @@ def test_render_field_with_classes(app, client, hello_form):
 
     response = client.get('/kwargs_class')
     data = response.get_data(as_text=True)
-    print(data)
     assert '<input class="form-control test" id="username" name="username"' in data
     assert '<input class="form-control test" id="password" name="password"' in data
+
+    @app.route('/general_kwargs')
+    def test_general_kwargs():
+        form = hello_form()
+        return render_template_string('''
+        {% from 'bootstrap/form.html' import render_field %}
+        {{ render_field(form.username, placeholder='test') }}
+        {{ render_field(form.password, placeholder='test') }}
+        {{ render_field(form.remember, class='test', value='n') }}
+        {{ render_field(form.submit, value='test') }}
+        ''', form=form)
+
+    response = client.get('/general_kwargs')
+    data = response.get_data(as_text=True)
+    assert '<input class="form-control" id="username" name="username" placeholder="test"' in data
+    assert '<input class="form-control" id="password" name="password" placeholder="test"' in data
+    assert '<input class="form-check-input test" id="remember" name="remember" type="checkbox" value="n"' in data
+    assert '<input class="btn btn-primary btn-md" id="submit" name="submit" type="submit" value="test"' in data

--- a/tests/test_render_field.py
+++ b/tests/test_render_field.py
@@ -19,3 +19,40 @@ def test_render_field(app, client, hello_form):
     assert '<label class="form-control-label" for="hidden">Hidden</label>' not in data
     assert '<input class="form-control" id="username" name="username"' in data
     assert '<input class="form-control" id="password" name="password"' in data
+
+
+def test_render_field_with_classes(app, client, hello_form):
+    @app.route('/render_kw_class')
+    def test_render_kw_class():
+        form = hello_form()
+        form.name.render_kw = {'class': 'render_kw_class'}
+        form.username.render_kw = {'class': 'render_kw_class'}
+        form.password.render_kw = {'class': 'render_kw_class'}
+        return render_template_string('''
+        {% from 'bootstrap/form.html' import render_field %}
+        {{ render_field(form.name) }}
+        {{ render_field(form.username, class_='test') }}
+        {{ render_field(form.password, class='test') }}
+        ''', form=form)
+
+    response = client.get('/render_kw_class')
+    data = response.get_data(as_text=True)
+    print(data)
+    assert '<input class="form-control render_kw_class" id="name" name="name"' in data
+    assert '<input class="form-control test" id="username" name="username"' in data
+    assert '<input class="form-control test" id="password" name="password"' in data
+
+    @app.route('/kwargs_class')
+    def test_kwargs_class():
+        form = hello_form()
+        return render_template_string('''
+        {% from 'bootstrap/form.html' import render_field %}
+        {{ render_field(form.username, class_='test') }}
+        {{ render_field(form.password, class='test') }}
+        ''', form=form)
+
+    response = client.get('/kwargs_class')
+    data = response.get_data(as_text=True)
+    print(data)
+    assert '<input class="form-control test" id="username" name="username"' in data
+    assert '<input class="form-control test" id="password" name="password"' in data


### PR DESCRIPTION
It supports to use `class` argument when using render_field:

```python
{{ render_field(form.username, class="myClass") }}
```

Bootstrap-Flask now combines the class you passed or the `class` value of `render_kw` with Bootstrap classes:

```html
<input class="form-control myClass" id="username" name="username"
```

This PR also fixes the issue that keyword arguments are not passed to BooleanField.

Related to #155 and #156.