### PR TITLE
Remove unnecessary whitespaces generated from if statements

### DIFF
--- a/flask_bootstrap/templates/bootstrap/form.html
+++ b/flask_bootstrap/templates/bootstrap/form.html
@@ -95,7 +95,7 @@ the necessary fix for required=False attributes, but will also not set the requi
             {%- if form_type == "inline" %}
                 {{ field.label(class="sr-only")|safe }}
             {% elif form_type == "horizontal" %}
-                {{ field.label(class="col-form-label " + (
+                {{ field.label(class="col-form-label" + (
                 " col-%s-%s" % horizontal_columns[0:2]))|safe }}
             {%- else -%}
                 {{ field.label(class="form-control-label")|safe }}
@@ -168,7 +168,7 @@ the necessary fix for required=False attributes, but will also not set the requi
                     {% endif %}
                 {% endif %}
             {% elif form_type == "horizontal" %}
-                {{ field.label(class="col-form-label " + (" col-%s-%s" % horizontal_columns[0:2]))|safe }}
+                {{ field.label(class="col-form-label" + (" col-%s-%s" % horizontal_columns[0:2]))|safe }}
                 <div class="col-{{ horizontal_columns[0] }}-{{ horizontal_columns[2] }}">
                     {% if field.type == 'FileField' %}
                         {% if field.errors %}

--- a/flask_bootstrap/templates/bootstrap/form.html
+++ b/flask_bootstrap/templates/bootstrap/form.html
@@ -101,7 +101,7 @@ the necessary fix for required=False attributes, but will also not set the requi
                 {{ field.label(class="form-control-label")|safe }}
             {% endif %}
             {% if form_type == 'horizontal' %}
-              <div class=" col-{{ horizontal_columns[0] }}-{{ horizontal_columns[2] }}">
+              <div class="col-{{ horizontal_columns[0] }}-{{ horizontal_columns[2] }}">
               {% endif %}
             {#% call _hz_form_wrap(horizontal_columns, form_type, True, required=required) %#}
             {% for item in field -%}
@@ -150,7 +150,7 @@ the necessary fix for required=False attributes, but will also not set the requi
             {%- endfor %}
         </fieldset>
     {% else -%}
-        <div class="form-group {%- if form_type == "horizontal" %} row{% endif -%}
+        <div class="form-group{%- if form_type == "horizontal" %} row{% endif -%}
                          {%- if field.flags.required %} required{% endif -%}">
             {%- if form_type == "inline" %}
                 {{ field.label(class="sr-only")|safe }}
@@ -169,7 +169,7 @@ the necessary fix for required=False attributes, but will also not set the requi
                 {% endif %}
             {% elif form_type == "horizontal" %}
                 {{ field.label(class="col-form-label " + (" col-%s-%s" % horizontal_columns[0:2]))|safe }}
-                <div class=" col-{{ horizontal_columns[0] }}-{{ horizontal_columns[2] }}">
+                <div class="col-{{ horizontal_columns[0] }}-{{ horizontal_columns[2] }}">
                     {% if field.type == 'FileField' %}
                         {% if field.errors %}
                             {{ field(class="form-control-file is-invalid%s" % extra_classes, **kwargs)|safe }}

--- a/flask_bootstrap/templates/bootstrap/nav.html
+++ b/flask_bootstrap/templates/bootstrap/nav.html
@@ -1,6 +1,6 @@
 {% macro render_nav_item(endpoint, text, badge='', use_li=False) %}
     {% if use_li %}<li class="nav-item">{% endif %}
-    <a class="{% if not use_li %}nav-item{% endif %} nav-link {% if request.endpoint and request.endpoint == endpoint %}active{% endif %}"
+    <a class="{% if not use_li %}nav-item {% endif %}nav-link{% if request.endpoint and request.endpoint == endpoint %} active{% endif %}"
        href="{{ url_for(endpoint, **kwargs) }}">
         {{ text }} {% if badge %}<span class="badge badge-light">{{ badge }}</span>{% endif %}
     </a>
@@ -9,7 +9,7 @@
 
 {% macro render_breadcrumb_item(endpoint, text) %}
     {% set active = True if request.endpoint and request.endpoint == endpoint else False %}
-    <li class="breadcrumb-item {% if active %}active{% endif %}" {% if active %}aria-current="page"{% endif %}>
+    <li class="breadcrumb-item{% if active %} active" aria-current="page"{% else %}"{% endif %}>
         {% if active %}
             {{ text }}
         {% else %}

--- a/flask_bootstrap/templates/bootstrap/pagination.html
+++ b/flask_bootstrap/templates/bootstrap/pagination.html
@@ -8,14 +8,14 @@
                       next=('Next <span aria-hidden="true">&rarr;</span>')|safe,
                       align='') -%}
     <nav aria-label="Page navigation">
-        <ul class="pagination {% if align == 'center' %}justify-content-center{% elif align == 'right' %}justify-content-end{% endif %}">
-            <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+        <ul class="pagination{% if align == 'center' %} justify-content-center{% elif align == 'right' %} justify-content-end{% endif %}">
+            <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
                 <a class="page-link"
                    href="{{ url_for(request.endpoint, page=pagination.prev_num, **kwargs) + fragment if pagination.has_prev else '#' }}">
                     {{ prev }}
                 </a>
             </li>
-            <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+            <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
                 <a class="page-link"
                    href="{{ url_for(request.endpoint, page=pagination.next_num, **kwargs) + fragment if pagination.has_next else '#' }}">
                     {{ next }}
@@ -42,10 +42,10 @@
        url_args.update(args) -%}
         {% with endpoint = endpoint or request.endpoint %}
             <nav aria-label="Page navigation">
-                <ul class="pagination{% if size %} pagination-{{ size }}{% endif %} {% if align == 'center' %}justify-content-center{% elif align == 'right' %}justify-content-end{% endif %}"{{ kwargs|xmlattr }}>
+                <ul class="pagination{% if size %} pagination-{{ size }}{% endif %}{% if align == 'center' %} justify-content-center{% elif align == 'right' %} justify-content-end{% endif %}"{{ kwargs|xmlattr }}>
                     {# prev and next are only show if a symbol has been passed. #}
                     {% if prev != None -%}
-                        <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+                        <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
                             <a class="page-link" href="{{ arg_url_for(endpoint, url_args, page=pagination.prev_num) if pagination.has_prev else '#' }}{{ fragment }}">{{ prev }}</a>
                         </li>
                     {%- endif -%}
@@ -67,7 +67,7 @@
                     {%- endfor %}
 
                     {% if next != None -%}
-                        <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+                        <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
                             <a class="page-link" href="{{ arg_url_for(endpoint, url_args, page=pagination.next_num) if pagination.has_next else '#' }}{{ fragment }}">{{ next }}</a>
                         </li>
                     {%- endif -%}

--- a/flask_bootstrap/templates/bootstrap/table.html
+++ b/flask_bootstrap/templates/bootstrap/table.html
@@ -56,7 +56,7 @@
     {% if caption %}
     <caption>{{ caption }}</caption>
     {% endif %}
-    <thead {% if header_classes %}class="{{ header_classes }}"{% endif %}>
+    <thead{% if header_classes %} class="{{ header_classes }}"{% endif %}>
     <tr>
     {% for title in titles %}
         <th scope="col">{{ title[1] }}</th>

--- a/tests/test_render_breadcrumb_item.py
+++ b/tests/test_render_breadcrumb_item.py
@@ -1,14 +1,25 @@
 from flask import render_template_string
 
 
-def test_render_breadcrumb_item(app, client):
-    @app.route('/breadcrumb_item')
-    def test():
+def test_render_breadcrumb_item_active(app, client):
+    @app.route('/not_active_item')
+    def foo():
         return render_template_string('''
                 {% from 'bootstrap/nav.html' import render_breadcrumb_item %}
-                {{ render_breadcrumb_item('test', 'Home') }}
+                {{ render_breadcrumb_item('bar', 'Bar') }}
                 ''')
 
-    response = client.get('/breadcrumb_item')
+    @app.route('/active_item')
+    def bar():
+        return render_template_string('''
+                {% from 'bootstrap/nav.html' import render_breadcrumb_item %}
+                {{ render_breadcrumb_item('bar', 'Bar') }}
+                ''')
+
+    response = client.get('/not_active_item')
+    data = response.get_data(as_text=True)
+    assert '<li class="breadcrumb-item">' in data
+
+    response = client.get('/active_item')
     data = response.get_data(as_text=True)
     assert '<li class="breadcrumb-item active" aria-current="page">' in data

--- a/tests/test_render_nav_item.py
+++ b/tests/test_render_nav_item.py
@@ -1,14 +1,25 @@
 from flask import render_template_string
 
 
-def test_render_nav_item(app, client):
-    @app.route('/nav_item')
-    def test():
+def test_render_nav_item_active(app, client):
+    @app.route('/active')
+    def foo():
         return render_template_string('''
                 {% from 'bootstrap/nav.html' import render_nav_item %}
-                {{ render_nav_item('test', 'Home') }}
+                {{ render_nav_item('foo', 'Foo') }}
                 ''')
 
-    response = client.get('/nav_item')
+    response = client.get('/active')
     data = response.get_data(as_text=True)
     assert '<a class="nav-item nav-link active"' in data
+
+    @app.route('/not_active')
+    def bar():
+        return render_template_string('''
+                {% from 'bootstrap/nav.html' import render_nav_item %}
+                {{ render_nav_item('foo', 'Foo') }}
+                ''')
+
+    response = client.get('/not_active')
+    data = response.get_data(as_text=True)
+    assert '<a class="nav-item nav-link"' in data


### PR DESCRIPTION
Continues #157 

Move some whitespace in HTML attributes to if statements.