### PR TITLE
render switch for boolean

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Release date: -
   - Bootstrap 4 macros are in the ``bootstrap4/`` template folder, and Bootstrap 5 macros are in ``bootstrap5/``.
   - Add seperate tests, templates, static files, and examples for Bootstrap 5.
 - Remove the deprecated ``form_errors`` macro and the URL string variable support in ``render_table``.
+- Render boolean field as a Bootstrap switch with ``SwitchField`` class.
 
 
 1.8.0

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -126,6 +126,24 @@ Here is a more complicate example:
 It will overwrite ``button_style`` and ``BOOTSTRAP_BTN_STYLE``.
 
 
+.. _check_box_customization:
+
+Form Check Box As Switch
+------------------------
+
+Bootstrap offers the rendering of a check box as a
+`switch <https://getbootstrap.com/docs/5.1/forms/checks-radios/#switches>`_. To
+enable this, add the following class:
+
+.. code-block:: python
+
+    class SwitchField(BooleanField):
+        def __init__(self, label=None, **kwargs):
+            super(SwitchField, self).__init__(label, **kwargs)
+
+Instead of using a ``BooleanField()`` in a form calls, use a ``SwitchField()``.
+This class has exactly the same properties but will be rendered as a switch.
+
 .. _bootswatch_theme:
 
 Bootswatch Themes

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -4,7 +4,7 @@ Advanced Usage
 .. _button_customization:
 
 Form Button Customization
---------------------------
+-------------------------
 
 Button Style
 ~~~~~~~~~~~~
@@ -126,12 +126,15 @@ Here is a more complicate example:
 It will overwrite ``button_style`` and ``BOOTSTRAP_BTN_STYLE``.
 
 
-.. _check_box_customization:
+.. _checkbox_customization:
 
-Form Check Box As Switch
-------------------------
+Form Checkbox Customization
+---------------------------
 
-Bootstrap offers the rendering of a check box as a
+Rendering Switch
+~~~~~~~~~~~~~~~~
+
+Bootstrap offers the rendering of a checkbox (or check) as a
 `switch <https://getbootstrap.com/docs/5.1/forms/checks-radios/#switches>`_. To
 enable this, add the following class:
 
@@ -142,7 +145,9 @@ enable this, add the following class:
             super(SwitchField, self).__init__(label, **kwargs)
 
 Instead of using a ``BooleanField()`` in a form calls, use a ``SwitchField()``.
-This class has exactly the same properties but will be rendered as a switch.
+This class has exactly the same properties but will be rendered as a switch. See
+also the example application.
+
 
 .. _bootswatch_theme:
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -135,18 +135,9 @@ Rendering Switch
 ~~~~~~~~~~~~~~~~
 
 Bootstrap offers the rendering of a checkbox (or check) as a
-`switch <https://getbootstrap.com/docs/5.1/forms/checks-radios/#switches>`_. To
-enable this, add the following class:
-
-.. code-block:: python
-
-    class SwitchField(BooleanField):
-        def __init__(self, label=None, **kwargs):
-            super().__init__(label, **kwargs)
-
-Instead of using a ``BooleanField()`` in a form calls, use a ``SwitchField()``.
-This class has exactly the same properties but will be rendered as a switch. See
-also the example application.
+`switch <https://getbootstrap.com/docs/5.1/forms/checks-radios/#switches>`_. In
+Bootstrap-Flask, simply use the built-in class ``SwitchField()`` instead of
+``BooleanField()``. See also the example application.
 
 
 .. _bootswatch_theme:

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -142,7 +142,7 @@ enable this, add the following class:
 
     class SwitchField(BooleanField):
         def __init__(self, label=None, **kwargs):
-            super(SwitchField, self).__init__(label, **kwargs)
+            super().__init__(label, **kwargs)
 
 Instead of using a ``BooleanField()`` in a form calls, use a ``SwitchField()``.
 This class has exactly the same properties but will be rendered as a switch. See

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -81,7 +81,7 @@ Example
         {{ render_field(form.submit) }}
     </form>
 
-You can pass any HTTP attributes as extra keyword arguements like ``class`` or ``placeholder``:
+You can pass any HTTP attributes as extra keyword arguments like ``class`` or ``placeholder``:
 
 .. code-block:: jinja
 
@@ -96,7 +96,7 @@ You can pass any HTTP attributes as extra keyword arguements like ``class`` or `
 
 Notice the ``class`` value here will overwrite the ``render_kw={'class': '...'}`` you defined in
 the form class. Bootstrap-Flask will combine the class value you passed with the ``class`` key of
-the ``render_kw`` dict or the ``class`` keyword argments with Bootstrap classes.
+the ``render_kw`` dict or the ``class`` keyword arguments with Bootstrap classes.
 
 
 API
@@ -116,7 +116,7 @@ API
     :param button_size: Set button size for ``SubmitField``. Accept Bootstrap button size name: sm, md, lg, block,
                         default to ``md``. This will overwrite config ``BOOTSTRAP_BTN_SIZE``.
 
-.. tip:: See :ref:`button_customization` to learn how to customize form buttons.
+.. tip:: See :ref:`button_customization` and :ref:`checkbox_customization` to learn more on customizations.
 
 render_form()
 ---------------

--- a/examples/bootstrap4/app.py
+++ b/examples/bootstrap4/app.py
@@ -34,7 +34,7 @@ csrf = CSRFProtect(app)
 
 class SwitchField(BooleanField):
     def __init__(self, label=None, **kwargs):
-        super(SwitchField, self).__init__(label, **kwargs)
+        super().__init__(label, **kwargs)
 
 
 class ExampleForm(FlaskForm):

--- a/examples/bootstrap4/app.py
+++ b/examples/bootstrap4/app.py
@@ -32,6 +32,11 @@ db = SQLAlchemy(app)
 csrf = CSRFProtect(app)
 
 
+class SwitchField(BooleanField):
+    def __init__(self, label=None, **kwargs):
+        super(SwitchField, self).__init__(label, **kwargs)
+
+
 class ExampleForm(FlaskForm):
     """An example form that contains all the supported bootstrap style form fields."""
     date = DateField(description="We'll never share your email with anyone else.")  # add help text with `description`
@@ -56,6 +61,7 @@ class HelloForm(FlaskForm):
 
 class ButtonForm(FlaskForm):
     username = StringField('Username', validators=[DataRequired(), Length(1, 20)])
+    confirm = SwitchField('Confirmation')
     submit = SubmitField()
     delete = SubmitField()
     cancel = SubmitField()

--- a/examples/bootstrap4/app.py
+++ b/examples/bootstrap4/app.py
@@ -7,7 +7,7 @@ from wtforms import StringField, SubmitField, BooleanField, PasswordField, Integ
 from wtforms.validators import DataRequired, Length
 from wtforms.fields import *
 
-from flask_bootstrap import Bootstrap4
+from flask_bootstrap import Bootstrap4, SwitchField
 from flask_sqlalchemy import SQLAlchemy
 
 app = Flask(__name__)
@@ -30,11 +30,6 @@ app.config['BOOTSTRAP_TABLE_NEW_TITLE'] = 'Create'
 bootstrap = Bootstrap4(app)
 db = SQLAlchemy(app)
 csrf = CSRFProtect(app)
-
-
-class SwitchField(BooleanField):
-    def __init__(self, label=None, **kwargs):
-        super().__init__(label, **kwargs)
 
 
 class ExampleForm(FlaskForm):

--- a/examples/bootstrap4/templates/base.html
+++ b/examples/bootstrap4/templates/base.html
@@ -37,7 +37,7 @@
                 {{ render_nav_item('test_table', 'Table', use_li=True) }}
                 {{ render_nav_item('test_icon', 'Icon', use_li=True) }}
                 <li class="nav-item"><a class="nav-link" href="https://bootstrap-flask.readthedocs.io/" target="_blank">Documentation</a></li>
-                <li class="nav-item"><a class="nav-link" href="https://getbootstrap.com/docs/4.5/getting-started/introduction/" target="_blank">Bootstrap Documentation</a></li>
+                <li class="nav-item"><a class="nav-link" href="https://getbootstrap.com/docs/4.6/getting-started/introduction/" target="_blank">Bootstrap Documentation</a></li>
                 <li class="nav-item"><a class="nav-link" href="https://github.com/greyli/bootstrap-flask" target="_blank">GitHub</a></li>
             </ul>
         </div>

--- a/examples/bootstrap5/app.py
+++ b/examples/bootstrap5/app.py
@@ -34,7 +34,7 @@ csrf = CSRFProtect(app)
 
 class SwitchField(BooleanField):
     def __init__(self, label=None, **kwargs):
-        super(SwitchField, self).__init__(label, **kwargs)
+        super().__init__(label, **kwargs)
 
 
 class ExampleForm(FlaskForm):

--- a/examples/bootstrap5/app.py
+++ b/examples/bootstrap5/app.py
@@ -7,7 +7,7 @@ from wtforms import StringField, SubmitField, BooleanField, PasswordField, Integ
 from wtforms.validators import DataRequired, Length
 from wtforms.fields import *
 
-from flask_bootstrap import Bootstrap5
+from flask_bootstrap import Bootstrap5, SwitchField
 from flask_sqlalchemy import SQLAlchemy
 
 app = Flask(__name__)
@@ -30,11 +30,6 @@ app.config['BOOTSTRAP_TABLE_NEW_TITLE'] = 'Create'
 bootstrap = Bootstrap5(app)
 db = SQLAlchemy(app)
 csrf = CSRFProtect(app)
-
-
-class SwitchField(BooleanField):
-    def __init__(self, label=None, **kwargs):
-        super().__init__(label, **kwargs)
 
 
 class ExampleForm(FlaskForm):

--- a/examples/bootstrap5/app.py
+++ b/examples/bootstrap5/app.py
@@ -32,6 +32,11 @@ db = SQLAlchemy(app)
 csrf = CSRFProtect(app)
 
 
+class SwitchField(BooleanField):
+    def __init__(self, label=None, **kwargs):
+        super(SwitchField, self).__init__(label, **kwargs)
+
+
 class ExampleForm(FlaskForm):
     """An example form that contains all the supported bootstrap style form fields."""
     date = DateField(description="We'll never share your email with anyone else.")  # add help text with `description`
@@ -56,6 +61,7 @@ class HelloForm(FlaskForm):
 
 class ButtonForm(FlaskForm):
     username = StringField('Username', validators=[DataRequired(), Length(1, 20)])
+    confirm = SwitchField('Confirmation')
     submit = SubmitField()
     delete = SubmitField()
     cancel = SubmitField()

--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -2,6 +2,7 @@ import warnings
 
 from flask import current_app, Markup, Blueprint, url_for
 
+from wtforms import BooleanField
 try:  # pragma: no cover
     from wtforms.fields import HiddenField
 except ImportError:
@@ -272,3 +273,12 @@ class Bootstrap(Bootstrap4):
             'is deprecated and will be removed in 3.0.',
             stacklevel=2
         )
+
+class SwitchField(BooleanField):
+    """
+    Extension class to a render Bootstrap switch for a boolean.
+
+    .. versionadded:: 2.0.0
+    """
+    def __init__(self, label=None, **kwargs):
+        super().__init__(label, **kwargs)

--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -274,6 +274,7 @@ class Bootstrap(Bootstrap4):
             stacklevel=2
         )
 
+
 class SwitchField(BooleanField):
     """
     Extension class to a render Bootstrap switch for a boolean.

--- a/flask_bootstrap/templates/bootstrap4/form.html
+++ b/flask_bootstrap/templates/bootstrap4/form.html
@@ -56,6 +56,15 @@ the necessary fix for required=False attributes, but will also not set the requi
     {% if field.widget.input_type == 'checkbox' %}
         {% set field_kwargs = kwargs %}
         {% call _hz_form_wrap(horizontal_columns, form_type, True, required=required) %}
+        {% if field.type == 'SwitchField' %}
+             <div class="custom-control custom-switch{% if form_type == "inline" %} form-check-inline{% endif %}">
+                {%- if field.errors %}
+                    {{ field(class_="custom-control-input is-invalid%s" % extra_classes)|safe }}
+                {%- else -%}
+                    {{ field(class_="custom-control-input%s" % extra_classes)|safe }}
+                {%- endif %}
+                {{ field.label(class="custom-control-label", for=field.id)|safe }}
+        {% else %}
             <div class="form-group form-check{% if form_type == "inline" %} form-check-inline{% endif %}">
                 {%- if field.errors %}
                     {{ field(class="form-check-input is-invalid%s" % extra_classes, **field_kwargs)|safe }}
@@ -63,6 +72,7 @@ the necessary fix for required=False attributes, but will also not set the requi
                     {{ field(class="form-check-input%s" % extra_classes, **field_kwargs)|safe }}
                 {%- endif %}
                 {{ field.label(class="form-check-label", for=field.id)|safe }}
+        {% endif %}
                 {%- if field.errors %}
                     {%- for error in field.errors %}
                         <div class="invalid-feedback" style="display: block;">{{ error }}</div>

--- a/tests/test_bootstrap4/test_render_form.py
+++ b/tests/test_bootstrap4/test_render_form.py
@@ -3,6 +3,7 @@ from flask_wtf import FlaskForm
 from wtforms import BooleanField, FileField, MultipleFileField,\
     PasswordField, RadioField, StringField, SubmitField
 from wtforms.validators import DataRequired
+from flask_bootstrap import SwitchField
 
 
 def test_render_form(app, client, hello_form):
@@ -37,6 +38,27 @@ def test_form_description_for_booleanfield(app, client):
     response = client.get('/description')
     data = response.get_data(as_text=True)
     assert 'Remember me' in data
+    assert '<small class="form-text text-muted">Just check this</small>' in data
+
+
+# test WTForm field description for SwitchField
+def test_form_description_for_switchfield(app, client):
+
+    class TestForm(FlaskForm):
+        remember = SwitchField('Remember me', description='Just check this')
+
+    @app.route('/description')
+    def description():
+        form = TestForm()
+        return render_template_string('''
+        {% from 'bootstrap4/form.html' import render_form %}
+        {{ render_form(form) }}
+        ''', form=form)
+
+    response = client.get('/description')
+    data = response.get_data(as_text=True)
+    assert 'Remember me' in data
+    assert 'custom-switch' in data
     assert '<small class="form-text text-muted">Just check this</small>' in data
 
 


### PR DESCRIPTION
Works for Bootstrap 4, not yet for Bootstrap 5. need help for that part.

The following one liner is probably the fix for version 5, but there is no forms.html for version 5 to add that.

    <div class="form-group form-check{% if form_type == "inline" %} form-check-inline{% endif %}{% if field.type == 'SwitchField' %} form-switch{% endif %}">