### PR TITLE
Add support for WTForms range fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release date: -
   parameter for ``render_form``, ``render_field``, and ``render_form_row``.
 - Add ``BOOTSTRAP_FORM_INLINE_CLASSES`` config for Bootstrap 5, defaults to ``row row-cols-lg-auto g-3 align-items-center``.
   Also add a ``form_inline_classes`` parameter for ``render_form``.
+- Add support for WTForms range fields (``DecimalRangeField`` and ``IntegerRangeField``).
 
 
 1.8.0

--- a/examples/bootstrap4/app.py
+++ b/examples/bootstrap4/app.py
@@ -32,12 +32,12 @@ class ExampleForm(FlaskForm):
     """An example form that contains all the supported bootstrap style form fields."""
     date = DateField(description="We'll never share your email with anyone else.")  # add help text with `description`
     datetime = DateTimeField(render_kw={'placeholder': 'this is a placeholder'})  # add HTML attribute with `render_kw`
-    datetimelocal = DateTimeLocalField()
+    datetime_local = DateTimeLocalField()
     time = TimeField()
     floating = FloatField()
     integer = IntegerField()
-    decimalslider = DecimalRangeField()
-    integerslider = IntegerRangeField(render_kw={'min': '0', 'max': '4'})
+    decimal_slider = DecimalRangeField()
+    integer_slider = IntegerRangeField(render_kw={'min': '0', 'max': '4'})
     email = EmailField()
     url = URLField()
     search = SearchField()
@@ -45,7 +45,7 @@ class ExampleForm(FlaskForm):
     image = FileField(render_kw={'class': 'my-class'}, validators=[Regexp('.+\.jpg$')])  # add your class
     option = RadioField(choices=[('dog', 'Dog'), ('cat', 'Cat'), ('bird', 'Bird'), ('alien', 'Alien')])
     select = SelectField(choices=[('dog', 'Dog'), ('cat', 'Cat'), ('bird', 'Bird'), ('alien', 'Alien')])
-    selectmulti = SelectMultipleField(choices=[('dog', 'Dog'), ('cat', 'Cat'), ('bird', 'Bird'), ('alien', 'Alien')])
+    select_multiple = SelectMultipleField(choices=[('dog', 'Dog'), ('cat', 'Cat'), ('bird', 'Bird'), ('alien', 'Alien')])
     bio = TextAreaField()
     title = StringField()
     secret = PasswordField()

--- a/examples/bootstrap5/app.py
+++ b/examples/bootstrap5/app.py
@@ -32,12 +32,12 @@ class ExampleForm(FlaskForm):
     """An example form that contains all the supported bootstrap style form fields."""
     date = DateField(description="We'll never share your email with anyone else.")  # add help text with `description`
     datetime = DateTimeField(render_kw={'placeholder': 'this is a placeholder'})  # add HTML attribute with `render_kw`
-    datetimelocal = DateTimeLocalField()
+    datetime_local = DateTimeLocalField()
     time = TimeField()
     floating = FloatField()
     integer = IntegerField()
-    decimalslider = DecimalRangeField()
-    integerslider = IntegerRangeField(render_kw={'min': '0', 'max': '4'})
+    decimal_slider = DecimalRangeField()
+    integer_slider = IntegerRangeField(render_kw={'min': '0', 'max': '4'})
     email = EmailField()
     url = URLField()
     search = SearchField()
@@ -45,7 +45,7 @@ class ExampleForm(FlaskForm):
     image = FileField(render_kw={'class': 'my-class'}, validators=[Regexp('.+\.jpg$')])  # add your class
     option = RadioField(choices=[('dog', 'Dog'), ('cat', 'Cat'), ('bird', 'Bird'), ('alien', 'Alien')])
     select = SelectField(choices=[('dog', 'Dog'), ('cat', 'Cat'), ('bird', 'Bird'), ('alien', 'Alien')])
-    selectmulti = SelectMultipleField(choices=[('dog', 'Dog'), ('cat', 'Cat'), ('bird', 'Bird'), ('alien', 'Alien')])
+    select_multiple = SelectMultipleField(choices=[('dog', 'Dog'), ('cat', 'Cat'), ('bird', 'Bird'), ('alien', 'Alien')])
     bio = TextAreaField()
     title = StringField()
     secret = PasswordField()

--- a/flask_bootstrap/templates/bootstrap4/form.html
+++ b/flask_bootstrap/templates/bootstrap4/form.html
@@ -156,6 +156,12 @@ the necessary fix for required=False attributes, but will also not set the requi
                     {% else %}
                         {{ field(class="form-control-file%s" % extra_classes, **kwargs)|safe }}
                     {% endif %}
+                {%- elif field.type in ['DecimalRangeField', 'IntegerRangeField'] -%}
+                    {% if field.errors %}
+                        {{ field(class="form-control-range is-invalid%s" % extra_classes, **kwargs)|safe }}
+                    {% else %}
+                        {{ field(class="form-control-range%s" % extra_classes, **kwargs)|safe }}
+                    {% endif %}
                 {% else %}
                     {% if field.errors %}
                         {{ field(class="form-control mb-2 mr-sm-2 mb-sm-0 is-invalid%s" % extra_classes, **kwargs)|safe }}
@@ -171,6 +177,12 @@ the necessary fix for required=False attributes, but will also not set the requi
                             {{ field(class="form-control-file is-invalid%s" % extra_classes, **kwargs)|safe }}
                         {% else %}
                             {{ field(class="form-control-file%s" % extra_classes, **kwargs)|safe }}
+                        {% endif %}
+                    {%- elif field.type in ['DecimalRangeField', 'IntegerRangeField'] -%}
+                        {% if field.errors %}
+                            {{ field(class="form-control-range is-invalid%s" % extra_classes, **kwargs)|safe }}
+                        {% else %}
+                            {{ field(class="form-control-range%s" % extra_classes, **kwargs)|safe }}
                         {% endif %}
                     {% else %}
                         {% if field.errors %}
@@ -198,6 +210,12 @@ the necessary fix for required=False attributes, but will also not set the requi
                         {{ field(class="form-control-file is-invalid%s" % extra_classes, **kwargs)|safe }}
                     {% else %}
                         {{ field(class="form-control-file%s" % extra_classes, **kwargs)|safe }}
+                    {% endif %}
+                {%- elif field.type in ['DecimalRangeField', 'IntegerRangeField'] -%}
+                    {% if field.errors %}
+                        {{ field(class="form-control-range is-invalid%s" % extra_classes, **kwargs)|safe }}
+                    {% else %}
+                        {{ field(class="form-control-range%s" % extra_classes, **kwargs)|safe }}
                     {% endif %}
                 {% else %}
                     {% if field.errors %}

--- a/flask_bootstrap/templates/bootstrap5/form.html
+++ b/flask_bootstrap/templates/bootstrap5/form.html
@@ -146,19 +146,35 @@ the necessary fix for required=False attributes, but will also not set the requi
                          {%- if field.flags.required %} required{% endif -%}">
             {%- if form_type == "inline" %}
                 {{ field.label(class="visually-hidden")|safe }}
-                {% if field.errors %}
-                    {{ field(class="form-control mb-2 mr-sm-2 mb-sm-0 is-invalid%s" % extra_classes, **kwargs)|safe }}
-                {% else %}
-                    {{ field(class="form-control mb-2 mr-sm-2 mb-sm-0%s" % extra_classes, **kwargs)|safe }}
-                {% endif %}
+                {%- if field.type in ['DecimalRangeField', 'IntegerRangeField'] %}
+                    {% if field.errors %}
+                        {{ field(class="form-range is-invalid%s" % extra_classes, **kwargs)|safe }}
+                    {% else %}
+                        {{ field(class="form-range%s" % extra_classes, **kwargs)|safe }}
+                    {% endif %}
+                {%- else -%}
+                    {% if field.errors %}
+                        {{ field(class="form-control mb-2 mr-sm-2 mb-sm-0 is-invalid%s" % extra_classes, **kwargs)|safe }}
+                    {% else %}
+                        {{ field(class="form-control mb-2 mr-sm-2 mb-sm-0%s" % extra_classes, **kwargs)|safe }}
+                    {% endif %}
+                {%- endif %}
             {% elif form_type == "horizontal" %}
                 {{ field.label(class="col-form-label" + (" col-%s-%s" % horizontal_columns[0:2]))|safe }}
                 <div class="col-{{ horizontal_columns[0] }}-{{ horizontal_columns[2] }}">
+                {%- if field.type in ['DecimalRangeField', 'IntegerRangeField'] %}
+                    {% if field.errors %}
+                        {{ field(class="form-range is-invalid%s" % extra_classes, **kwargs)|safe }}
+                    {% else %}
+                        {{ field(class="form-range%s" % extra_classes, **kwargs)|safe }}
+                    {% endif %}
+                {%- else -%}
                     {% if field.errors %}
                         {{ field(class="form-control is-invalid%s" % extra_classes, **kwargs)|safe }}
                     {% else %}
                         {{ field(class="form-control%s" % extra_classes, **kwargs)|safe }}
                     {% endif %}
+                {%- endif %}
                 </div>
                 {%- if field.errors %}
                     {%- for error in field.errors %}
@@ -173,11 +189,19 @@ the necessary fix for required=False attributes, but will also not set the requi
                 {%- endif %}
             {%- else -%}
                 {{ field.label(class="form-label")|safe }}
-                {% if field.errors %}
-                    {{ field(class="form-control is-invalid%s" % extra_classes, **kwargs)|safe }}
-                {% else %}
-                    {{ field(class="form-control%s" % extra_classes, **kwargs)|safe }}
-                {% endif %}
+                {%- if field.type in ['DecimalRangeField', 'IntegerRangeField'] %}
+                    {% if field.errors %}
+                        {{ field(class="form-range is-invalid%s" % extra_classes, **kwargs)|safe }}
+                    {% else %}
+                        {{ field(class="form-range%s" % extra_classes, **kwargs)|safe }}
+                    {% endif %}
+                {%- else -%}
+                    {% if field.errors %}
+                        {{ field(class="form-control is-invalid%s" % extra_classes, **kwargs)|safe }}
+                    {% else %}
+                        {{ field(class="form-control%s" % extra_classes, **kwargs)|safe }}
+                    {% endif %}
+                {%- endif %}
                 {%- if field.errors %}
                     {%- for error in field.errors %}
                         <div class="invalid-feedback" style="display: block;">{{ error }}</div>

--- a/tests/test_bootstrap4/test_render_form.py
+++ b/tests/test_bootstrap4/test_render_form.py
@@ -1,7 +1,8 @@
 from flask import current_app, render_template_string
 from flask_wtf import FlaskForm
 from wtforms import BooleanField, FileField, MultipleFileField,\
-    PasswordField, RadioField, StringField, SubmitField
+    PasswordField, RadioField, StringField, SubmitField, IntegerRangeField,\
+    DecimalRangeField
 from wtforms.validators import DataRequired
 from flask_bootstrap import SwitchField
 
@@ -42,7 +43,7 @@ def test_form_description_for_booleanfield(app, client):
 
 
 # test render SwitchField
-def test_switchfield(app, client):
+def test_switch_field(app, client):
 
     class TestForm(FlaskForm):
         remember = SwitchField('Remember me', description='Just check this')
@@ -60,6 +61,28 @@ def test_switchfield(app, client):
     assert 'Remember me' in data
     assert 'custom-switch' in data
     assert '<small class="form-text text-muted">Just check this</small>' in data
+
+
+# test render IntegerRangeField and DecimalRangeField
+def test_range_fields(app, client):
+
+    class TestForm(FlaskForm):
+        decimal_slider = DecimalRangeField()
+        integer_slider = IntegerRangeField(render_kw={'min': '0', 'max': '4'})
+
+    @app.route('/range')
+    def test_range():
+        form = TestForm()
+        return render_template_string('''
+        {% from 'bootstrap4/form.html' import render_form %}
+        {{ render_form(form) }}
+        ''', form=form)
+
+    response = client.get('/range')
+    data = response.get_data(as_text=True)
+    assert 'Decimal Slider' in data
+    assert 'Integer Slider' in data
+    assert 'form-control-range' in data
 
 
 # test WTForm fields for render_form and render_field

--- a/tests/test_bootstrap5/test_render_form.py
+++ b/tests/test_bootstrap5/test_render_form.py
@@ -1,9 +1,10 @@
 from flask import render_template_string
 from flask_wtf import FlaskForm
 from flask_bootstrap import SwitchField
+from wtforms import IntegerRangeField, DecimalRangeField
 
 
-def test_switchfield(app, client):
+def test_switch_field(app, client):
 
     class TestForm(FlaskForm):
         remember = SwitchField('Remember me', description='Just check this')
@@ -23,6 +24,28 @@ def test_switchfield(app, client):
     assert 'form-check form-switch' in data
     assert 'role="switch"' in data
     assert '<small class="form-text text-muted">Just check this</small>' in data
+
+
+# test render IntegerRangeField and DecimalRangeField
+def test_range_fields(app, client):
+
+    class TestForm(FlaskForm):
+        decimal_slider = DecimalRangeField()
+        integer_slider = IntegerRangeField(render_kw={'min': '0', 'max': '4'})
+
+    @app.route('/range')
+    def test_range():
+        form = TestForm()
+        return render_template_string('''
+        {% from 'bootstrap5/form.html' import render_form %}
+        {{ render_form(form) }}
+        ''', form=form)
+
+    response = client.get('/range')
+    data = response.get_data(as_text=True)
+    assert 'Decimal Slider' in data
+    assert 'Integer Slider' in data
+    assert 'form-range' in data
 
 
 def test_form_group_class(app, client, hello_form):


### PR DESCRIPTION
Render `DecimalRangeField` and `IntegerRangeField` for Bootstrap 4 and Bootstrap 5 correctly.

fixes #190 