### PR TITLE
Fix signature of Bootstrap.__init__() incompatible with older version.

### DIFF
--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -263,7 +263,7 @@ class Bootstrap5(_Bootstrap):
 
 
 class Bootstrap(Bootstrap4):
-    def __init__(self, app):
+    def __init__(self, app=None):
         super().__init__(app=app)
         warnings.warn(
             'For Bootstrap 4, please import and use "Bootstrap4" class, the "Bootstrap" class '


### PR DESCRIPTION
The `Bootstrap` class is now a subclass of `Bootstrap4`, and provides a deprecation warning. That should prevent existing code from breaking. However, this purpose is defeated by a change in the signature of `Bootstrap.__init__()` that can break existing code. 

This change restores the previous signature.