### PR TITLE
Fixed typos in examples

### DIFF
--- a/examples/bootstrap4/templates/table.html
+++ b/examples/bootstrap4/templates/table.html
@@ -6,7 +6,7 @@
 <pre>{% raw %}{{ render_table(messages) }}{% endraw %}</pre>
 {{ render_table(messages) }}
 
-<h2>Cutomized Table</h2>
+<h2>Customized Table</h2>
 <pre>{% raw %}{{ render_table(messages, titles, table_classes='table-striped', header_classes='thead-dark', caption='Messages') }}{% endraw %}</pre>
 {{ render_table(messages, titles, table_classes='table-striped', header_classes='thead-dark', caption='Messages') }}
 

--- a/examples/bootstrap5/templates/table.html
+++ b/examples/bootstrap5/templates/table.html
@@ -6,7 +6,7 @@
 <pre>{% raw %}{{ render_table(messages) }}{% endraw %}</pre>
 {{ render_table(messages) }}
 
-<h2>Cutomized Table</h2>
+<h2>Customized Table</h2>
 <pre>{% raw %}{{ render_table(messages, titles, table_classes='table-striped', header_classes='thead-dark', caption='Messages') }}{% endraw %}</pre>
 {{ render_table(messages, titles, table_classes='table-striped', header_classes='thead-dark', caption='Messages') }}
 


### PR DESCRIPTION
The word "Customized" was mistyped to "Cutomized" in the following files:

- https://github.com/greyli/bootstrap-flask/blame/master/examples/bootstrap4/templates/table.html#L9
- https://github.com/greyli/bootstrap-flask/blame/master/examples/bootstrap5/templates/table.html#L9

I fixed the spelling.

Fixes #206