### PR TITLE
Fix migration hyperlink in PyPI page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ Bootstrap-Flask is a collection of Jinja macros for Bootstrap 4 & 5 and Flask.
 It helps you to render Flask-related objects and data to Bootstrap HTML more easily.
 
 If you come from Flask-Bootstrap, check out
-[this tutorial](https://bootstrap-flask.readthedocs.io/en/latest/migrate.html)
+[this tutorial](https://bootstrap-flask.readthedocs.io/en/stable/migrate/)
 on how to migrate to this extension.
 
 Go to [GitHub page](https://github.com/greyli/bootstrap-flask), which you


### PR DESCRIPTION
The migration link from Flask-Bootstrap on the PyPI page is outdated.

It could be a good idea to include the whole README in the package's metadata to ensure [this page](https://pypi.org/project/Bootstrap-Flask/) is always up to date. If needed, here's how it's done in Flask: https://github.com/pallets/flask/blob/main/setup.cfg#L19.